### PR TITLE
增加全量复制

### DIFF
--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -5,9 +5,12 @@ mongo_urls = mongodb://username:password@127.0.0.1:20040,127.0.0.1:20041
 
 # collector name
 collector.id = mongoshake
+
 # sync mode: all/document/oplog
+# all means full synchronization + incremental synchronization
+# document means full synchronization
+# oplog means incremental synchronization
 sync_mode = all
-collection_rename = true
 
 # save checkpoint interval if necessary. 
 # the checkpoint will be checked and stored after starting 3 minutes.
@@ -92,7 +95,6 @@ tunnel = direct
 tunnel.address = mongodb://127.0.0.1:20080
 
 
-
 # collector context storage mainly including store checkpoint
 # type include : database, api
 # for api storage, address is http url
@@ -126,7 +128,7 @@ master_quorum = false
 replayer.dml_only = true
 
 # executors in single worker
-replayer.executor = 6
+replayer.executor = 1
 
 # oplog changes to Insert while Update found non-exist (_id or unique-index)
 replayer.executor.upsert = false
@@ -140,3 +142,19 @@ replayer.conflict_write_to = none
 # no any action(only for debugging enviroment) if 
 # set to false. otherwise write to ${mongo_url} instance
 replayer.durable = true
+
+
+# ----------------------splitter----------------------
+# full synchronization configuration
+
+# the number of collection concurrence
+replayer.collection_parallel = 6
+
+# the number of document concurrence in a collection concurrence
+replayer.document_parallel = 10
+
+# number of documents of batch insert in a document concurrence
+replayer.document_batch_size = 1000
+
+# rename collection to original name in full synchronization
+replayer.collection_rename = true

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -5,6 +5,9 @@ mongo_urls = mongodb://username:password@127.0.0.1:20040,127.0.0.1:20041
 
 # collector name
 collector.id = mongoshake
+# sync mode: all/document/oplog
+sync_mode = all
+collection_rename = true
 
 # save checkpoint interval if necessary. 
 # the checkpoint will be checked and stored after starting 3 minutes.
@@ -123,7 +126,7 @@ master_quorum = false
 replayer.dml_only = true
 
 # executors in single worker
-replayer.executor = 1
+replayer.executor = 6
 
 # oplog changes to Insert while Update found non-exist (_id or unique-index)
 replayer.executor.upsert = false

--- a/src/mongoshake/collector/checkpoint.go
+++ b/src/mongoshake/collector/checkpoint.go
@@ -15,10 +15,10 @@ import (
 	LOG "github.com/vinllen/log4go"
 )
 
-func (sync *OplogSyncer) newCheckpointManager(name string) {
+func (sync *OplogSyncer) newCheckpointManager(name string, startPosition int64) {
 	LOG.Info("Oplog sync create checkpoint manager with [%s] [%s]",
 		conf.Options.ContextStorage, conf.Options.ContextAddress)
-	sync.ckptManager = ckpt.NewCheckpointManager(name)
+	sync.ckptManager = ckpt.NewCheckpointManager(name, startPosition)
 }
 
 func (sync *OplogSyncer) checkpoint() {

--- a/src/mongoshake/collector/ckpt/ckpt_manager.go
+++ b/src/mongoshake/collector/ckpt/ckpt_manager.go
@@ -43,7 +43,7 @@ type CheckpointManager struct {
 	delegate CheckpointOperation
 }
 
-func NewCheckpointManager(name string) *CheckpointManager {
+func NewCheckpointManager(name string, startPosition int64) *CheckpointManager {
 	newManager := &CheckpointManager{}
 
 	switch conf.Options.ContextStorage {
@@ -51,7 +51,7 @@ func NewCheckpointManager(name string) *CheckpointManager {
 		newManager.delegate = &HttpApiCheckpoint{
 			Checkpoint: Checkpoint{
 				Name:          name,
-				StartPosition: conf.Options.ContextStartPosition,
+				StartPosition: startPosition,
 			},
 			URL: conf.Options.ContextAddress,
 		}
@@ -60,7 +60,7 @@ func NewCheckpointManager(name string) *CheckpointManager {
 		newManager.delegate = &MongoCheckpoint{
 			Checkpoint: Checkpoint{
 				Name:          name,
-				StartPosition: conf.Options.ContextStartPosition,
+				StartPosition: startPosition,
 			},
 			DB:    db,
 			URL:   conf.Options.ContextStorageUrl,

--- a/src/mongoshake/collector/configure/configure.go
+++ b/src/mongoshake/collector/configure/configure.go
@@ -27,7 +27,6 @@ type Configuration struct {
 	FilterNamespaceBlack    []string `config:"filter.namespace.black"`
 	FilterNamespaceWhite    []string `config:"filter.namespace.white"`
 	SyncMode                string   `config:"sync_mode"`
-	CollectionRename        bool     `config:"collection_rename"`
 
 	ReplayerDMLOnly                   bool   `config:"replayer.dml_only"`
 	ReplayerExecutor                  int    `config:"replayer.executor"`
@@ -36,6 +35,11 @@ type Configuration struct {
 	ReplayerCollisionEnable           bool   `config:"replayer.collision_detection"`
 	ReplayerConflictWriteTo           string `config:"replayer.conflict_write_to"`
 	ReplayerDurable                   bool   `config:"replayer.durable"`
+
+	ReplayerCollectionRename   bool `config:"replayer.collection_rename"`
+	ReplayerCollectionParallel int  `config:"replayer.collection_parallel"`
+	ReplayerDocumentParallel   int  `config:"replayer.document_parallel"`
+	ReplayerDocumentBatchSize  int  `config:"replayer.document_batch_size"`
 }
 
 func (configuration *Configuration) IsShardCluster() bool {

--- a/src/mongoshake/collector/configure/configure.go
+++ b/src/mongoshake/collector/configure/configure.go
@@ -15,8 +15,8 @@ type Configuration struct {
 	WorkerNum               int      `config:"worker"`
 	WorkerOplogCompressor   string   `config:"worker.oplog_compressor"`
 	WorkerBatchQueueSize    uint64   `config:"worker.batch_queue_size"`
-	AdaptiveBatchingMaxSize int   `config:"adaptive.batching_max_size"`
-	FetcherBufferCapacity   int   `config:"fetcher.buffer_capacity"`
+	AdaptiveBatchingMaxSize int      `config:"adaptive.batching_max_size"`
+	FetcherBufferCapacity   int      `config:"fetcher.buffer_capacity"`
 	Tunnel                  string   `config:"tunnel"`
 	TunnelAddress           []string `config:"tunnel.address"`
 	MasterQuorum            bool     `config:"master_quorum"`
@@ -26,6 +26,8 @@ type Configuration struct {
 	ContextStartPosition    int64    `config:"context.start_position" type:"date"`
 	FilterNamespaceBlack    []string `config:"filter.namespace.black"`
 	FilterNamespaceWhite    []string `config:"filter.namespace.white"`
+	SyncMode                string   `config:"sync_mode"`
+	CollectionRename        bool     `config:"collection_rename"`
 
 	ReplayerDMLOnly                   bool   `config:"replayer.dml_only"`
 	ReplayerExecutor                  int    `config:"replayer.executor"`

--- a/src/mongoshake/collector/docsyncer/doc_executor.go
+++ b/src/mongoshake/collector/docsyncer/doc_executor.go
@@ -41,10 +41,6 @@ func NewCollectionExecutor(ReplayerId uint32, mongoUrl string, ns dbpool.NS) *Co
 }
 
 func (batchExecutor *CollectionExecutor) Start() {
-	// max concurrent execute connection sets to 64. And the total
-	// conns = number of executor * number of batchExecutor. Normally max
-	// is 64. if collector hashed oplogRecords by _id and the number of collector
-	// is bigger we will use single executer in respective batchExecutor
 	parallel := conf.Options.ReplayerExecutor
 	batchExecutor.docBatch = make(chan []*bson.Raw, parallel)
 
@@ -59,7 +55,6 @@ func (batchExecutor *CollectionExecutor) Start() {
 func (batchExecutor *CollectionExecutor) Sync(docs []*bson.Raw) {
 	count := uint64(len(docs))
 	if count == 0 {
-		// may be probe request
 		return
 	}
 
@@ -137,11 +132,8 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 	}
 
 	if err := exec.session.DB(ns.Database).C(ns.Collection).Insert(idocs...); err != nil {
-		return fmt.Errorf("Insert docs[%v] into ns[%v] of dest mongo failed. %v", docs, ns, err)
+		return fmt.Errorf("Insert docs [%v] into ns %v of dest mongo failed. %v", docs, ns, err)
 	}
-
-	//LOG.Info("Replayer-%d Executor-%d doSync doc ns[%v] received[%d].",
-	//	exec.batchExecutor.replayerId, exec.id, exec.batchExecutor.ns, len(docs))
 
 	return nil
 }

--- a/src/mongoshake/collector/docsyncer/doc_executor.go
+++ b/src/mongoshake/collector/docsyncer/doc_executor.go
@@ -1,0 +1,169 @@
+package docsyncer
+
+import (
+	"errors"
+	"fmt"
+	"github.com/vinllen/mgo/bson"
+	"mongoshake/dbpool"
+	"sync"
+	"sync/atomic"
+
+	"mongoshake/collector/configure"
+
+	LOG "github.com/vinllen/log4go"
+	"github.com/vinllen/mgo"
+)
+
+var GlobalDocExecutorId int32 = -1
+
+
+type CollectionExecutor struct {
+	// multi executor
+	executors []*DocExecutor
+	// worker id
+	replayerId uint32
+	// mongo url
+	mongoUrl string
+
+	ns dbpool.NS
+
+	wg sync.WaitGroup
+
+	docBatch chan []*bson.Raw
+}
+
+func NewCollectionExecutor(ReplayerId uint32, mongoUrl string, ns dbpool.NS) *CollectionExecutor {
+	return &CollectionExecutor{
+		replayerId: ReplayerId,
+		mongoUrl:   mongoUrl,
+		ns:         ns,
+	}
+}
+
+func (batchExecutor *CollectionExecutor) Start() {
+	// max concurrent execute connection sets to 64. And the total
+	// conns = number of executor * number of batchExecutor. Normally max
+	// is 64. if collector hashed oplogRecords by _id and the number of collector
+	// is bigger we will use single executer in respective batchExecutor
+	parallel := conf.Options.ReplayerExecutor
+	batchExecutor.docBatch = make(chan []*bson.Raw, parallel)
+
+	executors := make([]*DocExecutor, parallel)
+	for i := 0; i != len(executors); i++ {
+		executors[i] = NewDocExecutor(GenerateDocExecutorId(), batchExecutor)
+		go executors[i].start()
+	}
+	batchExecutor.executors = executors
+}
+
+func (batchExecutor *CollectionExecutor) Sync(docs []*bson.Raw) {
+	count := uint64(len(docs))
+	if count == 0 {
+		// may be probe request
+		return
+	}
+
+	batchExecutor.wg.Add(1)
+	batchExecutor.docBatch <- docs
+}
+
+func (batchExecutor *CollectionExecutor) Wait() error {
+	batchExecutor.wg.Wait()
+	close(batchExecutor.docBatch)
+
+	for _, exec := range batchExecutor.executors {
+		if exec.error != nil {
+			return errors.New(fmt.Sprintf("batch sync ns %v failed. %v", batchExecutor.ns, exec.error))
+		}
+	}
+	return nil
+}
+
+
+type DocExecutor struct {
+	// sequence index id in each replayer
+	id int
+	// batchExecutor, not owned
+	batchExecutor *CollectionExecutor
+
+	error error
+	// mongo connection
+	session *mgo.Session
+}
+
+func GenerateDocExecutorId() int {
+	return int(atomic.AddInt32(&GlobalDocExecutorId, 1))
+}
+
+func NewDocExecutor(id int, batchExecutor *CollectionExecutor) *DocExecutor {
+	return &DocExecutor{
+		id:            	id,
+		batchExecutor: 	batchExecutor,
+	}
+}
+
+func (exec *DocExecutor) start() {
+	for {
+		docs, ok := <- exec.batchExecutor.docBatch
+		if !ok {
+			break
+		}
+
+		if exec.error == nil {
+			if err := exec.doSync(docs); err != nil {
+				exec.error = err
+			}
+		}
+
+		exec.batchExecutor.wg.Done()
+	}
+
+	exec.dropConnection()
+
+	LOG.Info("doc executor Replayer-%d Executor-%d end",
+		exec.batchExecutor.replayerId, exec.id)
+}
+
+func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
+	if !exec.ensureConnection() {
+		return errors.New("network connection lost. we would retry for next connecting")
+	}
+
+	ns := exec.batchExecutor.ns
+
+	var idocs []interface{}
+	for _, doc := range docs {
+		idocs = append(idocs, doc)
+	}
+
+	if err := exec.session.DB(ns.Database).C(ns.Collection).Insert(idocs...); err != nil {
+		return fmt.Errorf("Insert docs[%v] into ns[%v] of dest mongo failed. %v", docs, ns, err)
+	}
+
+	//LOG.Info("Replayer-%d Executor-%d doSync doc ns[%v] received[%d].",
+	//	exec.batchExecutor.replayerId, exec.id, exec.batchExecutor.ns, len(docs))
+
+	return nil
+}
+
+
+func (exec *DocExecutor) ensureConnection() bool {
+	// reconnect if necessary
+	if exec.session == nil {
+		if conn, err := dbpool.NewMongoConn(exec.batchExecutor.mongoUrl, true); err != nil {
+			LOG.Critical("Connect to mongo cluster failed. %v", err)
+			return false
+		} else {
+			exec.session = conn.Session
+		}
+	}
+
+	return true
+}
+
+func (exec *DocExecutor) dropConnection() {
+	if exec.session != nil {
+		exec.session.Close()
+		exec.session = nil
+	}
+}

--- a/src/mongoshake/collector/docsyncer/doc_executor.go
+++ b/src/mongoshake/collector/docsyncer/doc_executor.go
@@ -41,7 +41,7 @@ func NewCollectionExecutor(ReplayerId uint32, mongoUrl string, ns dbpool.NS) *Co
 }
 
 func (batchExecutor *CollectionExecutor) Start() {
-	parallel := conf.Options.ReplayerExecutor
+	parallel := conf.Options.ReplayerDocumentParallel
 	batchExecutor.docBatch = make(chan []*bson.Raw, parallel)
 
 	executors := make([]*DocExecutor, parallel)
@@ -115,7 +115,7 @@ func (exec *DocExecutor) start() {
 
 	exec.dropConnection()
 
-	LOG.Info("doc executor Replayer-%d Executor-%d end",
+	LOG.Info("document replayer-%d executor-%d end",
 		exec.batchExecutor.replayerId, exec.id)
 }
 

--- a/src/mongoshake/collector/docsyncer/doc_reader.go
+++ b/src/mongoshake/collector/docsyncer/doc_reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/vinllen/mgo"
 	"github.com/vinllen/mgo/bson"
+	"mongoshake/common"
 	"mongoshake/dbpool"
 )
 
@@ -21,7 +22,7 @@ func GetAllNamespace(src string) (allNs []dbpool.NS, err error) {
 	}
 	allNs = make([]dbpool.NS, 0, 128)
 	for _, db := range dbNames {
-		if db != "admin" && db != "local" {
+		if db != "admin" && db != "local" && db != utils.AppDatabase {
 			colNames, err := conn.Session.DB(db).CollectionNames()
 			if err != nil {
 				err = fmt.Errorf("get collection names of mongodb instance [%s] error. %s", src, err.Error())
@@ -51,7 +52,7 @@ type DocumentReader struct {
 	query bson.M
 }
 
-// NewOplogReader creates reader with mongodb url
+// NewDocumentReader creates reader with mongodb url
 func NewDocumentReader(src string, ns dbpool.NS) *DocumentReader {
 	return &DocumentReader{src: src, ns: ns, query: bson.M{}}
 }

--- a/src/mongoshake/collector/docsyncer/doc_reader.go
+++ b/src/mongoshake/collector/docsyncer/doc_reader.go
@@ -1,0 +1,122 @@
+package docsyncer
+
+import (
+	"fmt"
+	"github.com/vinllen/mgo"
+	"github.com/vinllen/mgo/bson"
+	"mongoshake/dbpool"
+)
+
+
+func GetAllNamespace(src string) (allNs []dbpool.NS, err error) {
+	var conn *dbpool.MongoConn
+	if conn, err = dbpool.NewMongoConn(src, false); conn == nil || err != nil {
+		err = fmt.Errorf("connect mongodb instance [%s] error. %s", src, err.Error())
+		return nil, err
+	}
+	var dbNames []string
+	if dbNames, err = conn.Session.DatabaseNames(); err != nil {
+		err = fmt.Errorf("get database names of mongodb instance [%s] error. %s", src, err.Error())
+		return nil, err
+	}
+	allNs = make([]dbpool.NS, 0, 128)
+	for _, db := range dbNames {
+		if db != "admin" && db != "local" {
+			colNames, err := conn.Session.DB(db).CollectionNames()
+			if err != nil {
+				err = fmt.Errorf("get collection names of mongodb instance [%s] error. %s", src, err.Error())
+				return nil, err
+			}
+			for _, col := range colNames {
+				if col != "system.profile" {
+					allNs = append(allNs, dbpool.NS{Database:db, Collection:col})
+				}
+			}
+		}
+	}
+	return allNs, nil
+}
+
+
+type DocumentReader struct {
+	// source mongo address url
+	src string
+	ns dbpool.NS
+
+	// mongo document reader
+	conn          	*dbpool.MongoConn
+	docIterator 	*mgo.Iter
+
+	// query statement and current max cursor
+	query bson.M
+}
+
+// NewOplogReader creates reader with mongodb url
+func NewDocumentReader(src string, ns dbpool.NS) *DocumentReader {
+	return &DocumentReader{src: src, ns: ns, query: bson.M{}}
+}
+
+
+// NextDoc returns an document by raw bytes which is []byte
+func (reader *DocumentReader) NextDoc() (doc *bson.Raw, err error) {
+	if err := reader.ensureNetwork(); err != nil {
+		return nil, err
+	}
+
+	doc = new(bson.Raw)
+
+	if !reader.docIterator.Next(doc) {
+		if err := reader.docIterator.Err(); err != nil {
+			// some internal error. need rebuild the oplogsIterator
+			reader.releaseIterator()
+			return nil, fmt.Errorf("get next doc failed. release oplogsIterator, %s", err.Error())
+		} else {
+			return nil, nil
+		}
+	}
+	return doc, nil
+}
+
+func (reader *DocumentReader) GetIndexes() ([]mgo.Index, error) {
+	return reader.conn.Session.DB(reader.ns.Database).C(reader.ns.Collection).Indexes()
+}
+
+// ensureNetwork establish the mongodb connection at first
+// if current connection is not ready or disconnected
+func (reader *DocumentReader) ensureNetwork() (err error) {
+	if reader.docIterator != nil {
+		return nil
+	}
+	if reader.conn == nil || (reader.conn != nil && !reader.conn.IsGood()) {
+		if reader.conn != nil {
+			reader.conn.Close()
+		}
+		// reconnect
+		if reader.conn, err = dbpool.NewMongoConn(reader.src, false); reader.conn == nil || err != nil {
+			err = fmt.Errorf("reconnect mongodb instance [%s] error. %s", reader.src, err.Error())
+			return err
+		}
+	}
+
+	// rebuild syncerGroup condition statement with current checkpoint timestamp
+	reader.conn.Session.SetBatch(8192)
+	reader.conn.Session.SetPrefetch(0.2)
+	reader.conn.Session.SetCursorTimeout(0)
+	reader.docIterator = reader.conn.Session.DB(reader.ns.Database).C(reader.ns.Collection).
+		Find(reader.query).Snapshot().Iter()
+	return nil
+}
+
+func (reader *DocumentReader) releaseIterator() {
+	if reader.docIterator != nil {
+		reader.docIterator.Close()
+	}
+	reader.docIterator = nil
+}
+
+func (reader *DocumentReader) Close() {
+	if reader.conn != nil {
+		reader.conn.Close()
+		reader.conn = nil
+	}
+}

--- a/src/mongoshake/collector/docsyncer/doc_syncer.go
+++ b/src/mongoshake/collector/docsyncer/doc_syncer.go
@@ -31,8 +31,6 @@ type DocumentSyncer struct {
 	toMongoConn		*dbpool.MongoConn
 
 	replMetric 		*utils.ReplicationMetric
-
-	syncError		error
 }
 
 func NewDocumentSyncer(
@@ -113,7 +111,7 @@ func (syncer *DocumentSyncer) prepare(wg *sync.WaitGroup) (err error) {
 func (syncer *DocumentSyncer) collectionSync(replayerId uint32, ns dbpool.NS) error {
 	reader := NewDocumentReader(syncer.fromMongoUrl, ns)
 
-	toColName := fmt.Sprintf("%s_%s", ns.Collection, conf.Options.CollectorId)
+	toColName := fmt.Sprintf("%s_%s", ns.Collection, utils.APPNAME)
 
 	toNS := dbpool.NS{Database:ns.Database, Collection:toColName}
 

--- a/src/mongoshake/collector/docsyncer/doc_syncer.go
+++ b/src/mongoshake/collector/docsyncer/doc_syncer.go
@@ -1,0 +1,171 @@
+package docsyncer
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gugemichael/nimo4go"
+	"github.com/vinllen/mgo/bson"
+	"mongoshake/collector/configure"
+	"mongoshake/common"
+	"mongoshake/dbpool"
+	"sync"
+	"time"
+
+	LOG "github.com/vinllen/log4go"
+)
+
+const (
+	DocBufferCapacity = 1000
+)
+
+type DocumentSyncer struct {
+	// source mongodb url
+	fromMongoUrl 	string
+	// destination mongodb url
+	toMongoUrl 		string
+	// namespace need to sync
+	namespaces 		chan dbpool.NS
+	// start time of sync
+	startTime 		time.Time
+	// destination mongodb connection
+	toMongoConn		*dbpool.MongoConn
+
+	replMetric 		*utils.ReplicationMetric
+
+	syncError		error
+}
+
+func NewDocumentSyncer(
+	fromMongoUrl string,
+	toMongoUrl string) *DocumentSyncer {
+
+	syncer := &DocumentSyncer{
+		fromMongoUrl: fromMongoUrl,
+		toMongoUrl:   toMongoUrl,
+		namespaces:   make(chan dbpool.NS, conf.Options.WorkerNum),
+	}
+
+	return syncer
+}
+
+func (syncer *DocumentSyncer) Start() error {
+	syncer.startTime = time.Now()
+	var wg sync.WaitGroup
+
+	if err := syncer.prepare(&wg); err != nil {
+		return errors.New(fmt.Sprintf("document syncer init transfer error. %v", err))
+	}
+
+	var syncError error
+	for i := 0; i < conf.Options.WorkerNum; i++ {
+		ind := i
+		nimo.GoRoutine(func() {
+			for {
+				ns, ok := <- syncer.namespaces
+				if !ok {
+					break
+				}
+
+				LOG.Info("Replayer-%v sync ns %v begin", ind, ns)
+				if err := syncer.collectionSync(uint32(ind), ns); err != nil {
+					LOG.Critical("Replayer-%v sync ns %v failed. %v", ind, ns, err)
+					syncError = errors.New(fmt.Sprintf("document syncer sync ns %v failed. %v", ns, err))
+				} else {
+					LOG.Info("Replayer-%v sync ns %v successful", ind, ns)
+				}
+
+				wg.Done()
+			}
+			LOG.Info("Replayer-%v finish", ind)
+		})
+	}
+
+	wg.Wait()
+	close(syncer.namespaces)
+
+	if syncer.toMongoConn != nil {
+		syncer.toMongoConn.Close()
+	}
+
+	return syncError
+}
+
+func (syncer *DocumentSyncer) prepare(wg *sync.WaitGroup) (err error) {
+	var nslist []dbpool.NS
+	if nslist, err = GetAllNamespace(syncer.fromMongoUrl); err != nil {
+		return err
+	}
+
+	if syncer.toMongoConn, err = dbpool.NewMongoConn(syncer.toMongoUrl,true); err != nil {
+		return errors.New(fmt.Sprintf("Connect to dest mongo failed. %v", err))
+	}
+
+	wg.Add(len(nslist))
+
+	nimo.GoRoutine(func() {
+		for _, ns := range nslist {
+			syncer.namespaces <- ns
+		}
+	})
+	return nil
+}
+
+func (syncer *DocumentSyncer) collectionSync(replayerId uint32, ns dbpool.NS) error {
+	reader := NewDocumentReader(syncer.fromMongoUrl, ns)
+
+	toColName := fmt.Sprintf("%s_%s", ns.Collection, conf.Options.CollectorId)
+
+	toNS := dbpool.NS{Database:ns.Database, Collection:toColName}
+
+	batchExecutor := NewCollectionExecutor(replayerId, syncer.toMongoUrl, toNS)
+	batchExecutor.Start()
+
+	buffer := make([]*bson.Raw, 0, DocBufferCapacity)
+
+	var err error
+	for {
+		var doc *bson.Raw
+		if doc, err = reader.NextDoc(); err != nil {
+			return errors.New(fmt.Sprintf("Get next document from ns %v of src mongodb failed. %v", ns, err))
+		} else if doc == nil {
+			batchExecutor.Sync(buffer)
+			if err := batchExecutor.Wait(); err != nil {
+				return err
+			}
+			break
+		}
+		buffer = append(buffer, doc)
+		if len(buffer) >= DocBufferCapacity {
+			batchExecutor.Sync(buffer)
+			buffer = make([]*bson.Raw, 0, DocBufferCapacity)
+		}
+	}
+
+	LOG.Info("Replayer-%v sync index ns %v begin", replayerId, ns)
+
+	if indexes, err := reader.GetIndexes(); err != nil {
+		return errors.New(fmt.Sprintf("Get indexes from ns %v of src mongodb failed. %v", ns, err))
+	} else {
+		for _, index := range indexes {
+			index.Background = false
+			if err = syncer.toMongoConn.Session.DB(toNS.Database).C(toNS.Collection).EnsureIndex(index); err != nil {
+				return errors.New(fmt.Sprintf("Create indexes for ns %v of dest mongodb failed. %v", ns, err))
+			}
+		}
+	}
+
+	reader.Close()
+	LOG.Info("Replayer-%v sync index for ns %v successful", replayerId, ns)
+
+	if conf.Options.CollectionRename {
+		err := syncer.toMongoConn.Session.DB("admin").
+			Run(bson.D{{"renameCollection",toNS.Str()},{"to",ns.Str()}},nil)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Rename Collection ns %v of dest mongodb to ns %v failed. %v",
+							toNS, ns, err))
+		}
+		LOG.Info("Rename collection ns %v of dest mongodb to ns %v successful", toNS, ns)
+	}
+
+	return nil
+}

--- a/src/mongoshake/collector/oplog_reader.go
+++ b/src/mongoshake/collector/oplog_reader.go
@@ -3,13 +3,13 @@ package collector
 import (
 	"errors"
 	"fmt"
-	"time"
-	"sync"
 	"strings"
+	"sync"
+	"time"
 
+	"mongoshake/collector/configure"
 	"mongoshake/dbpool"
 	"mongoshake/oplog"
-	"mongoshake/collector/configure"
 
 	LOG "github.com/vinllen/log4go"
 	"github.com/vinllen/mgo"
@@ -177,11 +177,12 @@ func (reader *OplogReader) ensureNetwork() (err error) {
 	var queryTs bson.MongoTimestamp
 	// the given oplog timestamp shouldn't bigger than the newest
 	if reader.firstRead == true {
-		// check whether the starting fetching timestamp is less than the oldest timestamp exist in the oplog
+		// check whether the starting fetching timestamp is less than the newest timestamp exist in the oplog
 		newestTs := reader.getNewestTimestamp()
 		queryTs = reader.query[QueryTs].(bson.M)[QueryOpGTE].(bson.MongoTimestamp)
 		if newestTs < queryTs {
-			return fmt.Errorf("current starting point[%v] is bigger than the newest timestamp[%v]", queryTs, newestTs)
+			LOG.Warn("current starting point[%v] is bigger than the newest timestamp[%v]", queryTs, newestTs)
+			queryTs = newestTs
 		}
 	}
 

--- a/src/mongoshake/collector/replication.go
+++ b/src/mongoshake/collector/replication.go
@@ -133,15 +133,18 @@ func (coordinator *ReplicationCoordinator) sanitizeMongoDB() error {
 }
 
 func (coordinator *ReplicationCoordinator) startDocumentReplication() error {
-	var wg sync.WaitGroup
+	if conf.Options.Tunnel != "direct" {
+		return errors.New("document replication only support direct tunnel type")
+	}
 
+	var wg sync.WaitGroup
 	var replError error
 	for _, src := range coordinator.Sources {
 		docSyncer := docsyncer.NewDocumentSyncer(src.URL, conf.Options.TunnelAddress[0])
 		wg.Add(1)
 		nimo.GoRoutine(func() {
 			if err := docSyncer.Start(); err != nil {
-				LOG.Critical("Document Replication for url=%v failed. %v", src.URL, err)
+				LOG.Critical("document replication for url=%v failed. %v", src.URL, err)
 				replError = err
 			}
 			wg.Done()

--- a/src/mongoshake/collector/syncer.go
+++ b/src/mongoshake/collector/syncer.go
@@ -40,6 +40,8 @@ type OplogSyncer struct {
 	coordinator *ReplicationCoordinator
 	// source mongodb replica set name
 	replset string
+	// oplog start position of source mongodb
+	startPosition int64
 
 	ckptManager *ckpt.CheckpointManager
 
@@ -78,12 +80,14 @@ type OplogSyncer struct {
 func NewOplogSyncer(
 	coordinator *ReplicationCoordinator,
 	replset string,
+	startPosition int64,
 	mongoUrl string,
 	gid string) *OplogSyncer {
 
 	syncer := &OplogSyncer{
 		coordinator: coordinator,
 		replset:     replset,
+		startPosition:	startPosition,
 		journal: utils.NewJournal(utils.JournalFileName(
 			fmt.Sprintf("%s.%s", conf.Options.CollectorId, replset))),
 		reader: NewOplogReader(mongoUrl),
@@ -144,7 +148,7 @@ func (sync *OplogSyncer) start() {
 	// 1. create checkpoint manager
 	// 2. load existing ckpt from remote storage
 	// 3. start checkpoint persist routine
-	sync.newCheckpointManager(sync.replset)
+	sync.newCheckpointManager(sync.replset, sync.startPosition)
 
 	// start batcher and deserializer
 	sync.startDeserializer()

--- a/src/mongoshake/dbpool/session.go
+++ b/src/mongoshake/dbpool/session.go
@@ -1,6 +1,7 @@
 package dbpool
 
 import (
+	"fmt"
 	"time"
 
 	LOG "github.com/vinllen/log4go"
@@ -9,6 +10,15 @@ import (
 )
 
 const OplogNS = "oplog.rs"
+
+type NS struct {
+	Database   string
+	Collection string
+}
+
+func (ns NS) Str() string {
+	return fmt.Sprintf("%s.%s", ns.Database, ns.Collection)
+}
 
 type MongoConn struct {
 	Session *mgo.Session
@@ -77,11 +87,6 @@ func (conn *MongoConn) HasOplogNs() bool {
 }
 
 func (conn *MongoConn) HasUniqueIndex() bool {
-	type NS struct {
-		Database   string
-		Collection string
-	}
-
 	checkNs := make([]NS, 0, 128)
 	var databases []string
 	var err error


### PR DESCRIPTION
1.全量复制和增量复制可以一起执行，也可以分别执行，通过参数sync_mode进行配置
2.全量复制不直接在目的段创建同名的表，而是创建以_collector.id结尾的表，在数据和索引同步完之后，再根据参数collection_rename选择是否将表重命名为原来的表名。注意，如果sync_mode设为all，那么collection_rename要设为true。
3.参数worker可以设置全量复制的表并发度，参数replayer.executor可以设置全量复制的行并发度
4.如果全量复制报错失败，那么后续的增量复制不会再继续执行
5.全量复制不会对admin和local库进行同步，也不会同步其他库中的system.profile表