### PR TITLE
Backoff when executor encounter error

### DIFF
--- a/src/mongoshake/executor/executor.go
+++ b/src/mongoshake/executor/executor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"mongoshake/collector/configure"
 	"mongoshake/common"
@@ -191,6 +192,7 @@ func (exec *Executor) start() {
 	for toBeExecuted := range exec.batchBlock {
 		nimo.AssertTrue(len(toBeExecuted) != 0, "the size of being executed batch oplogRecords could not be zero")
 		for exec.doSync(toBeExecuted) != nil {
+			time.Sleep(time.Second)
 		}
 		// acknowledge all oplogRecords have been successfully executed
 		exec.finisher.Add(-len(toBeExecuted))


### PR DESCRIPTION
At present, executor use a dead loop to execute, which may report a log of error in exceptional scenario.

The improvement is that: sleep a while and try again.