### PR TITLE
collector: fix potential forgetting unlock in Persister.Inject

### DIFF
--- a/src/mongoshake/collector/persister.go
+++ b/src/mongoshake/collector/persister.go
@@ -155,6 +155,7 @@ func (p *Persister) Inject(input []byte) {
 
 			// store local
 			p.diskQueueMutex.Lock()
+			defer p.diskQueueMutex.Unlock()
 			if p.DiskQueue != nil { // double check
 				// should send to diskQueue
 				atomic.AddUint64(&p.diskWriteCount, 1)


### PR DESCRIPTION
**Description**
This patch fixes a potential forgetting unlock bug in `Persister.Inject`, which may lead to a deadlock.
In src/mongoshake/collector/persister.go,
Function `Inject` calls `p.diskQueueMutex.Lock()` but forgets `p.diskQueueMutex.Unlock()` on a specific branch.
https://github.com/alibaba/MongoShake/blob/313fc4ebf915324cf6ec793b52db48ff04c174a8/src/mongoshake/collector/persister.go#L157-L168
`Inject` is called by `next` in syncer.go, and `next` is called multiple times by `poll`. 
So it is possible that `p.disQueueMutex.Lock()` is acquired twice, leading to a deadlock.
https://github.com/alibaba/MongoShake/blob/313fc4ebf915324cf6ec793b52db48ff04c174a8/src/mongoshake/collector/syncer.go#L486
https://github.com/alibaba/MongoShake/blob/313fc4ebf915324cf6ec793b52db48ff04c174a8/src/mongoshake/collector/syncer.go#L443-L451

**Fix**
The fix is to add a `defer p.diskQueueMutex.Unlock()` right after `p.diskQueueMutex.Lock()`. This way `Unlock` is always called as long as `Lock` is called, even if there is a panic (LOG.Crashf).

**Suggestions**
One interesting thing is that there is a unit testing `TestInject` in src/mongoshake/collector/persister_test.go.
But it fails to detect this potential deadlock because of the limited configurations.
e.g.
https://github.com/alibaba/MongoShake/blob/313fc4ebf915324cf6ec793b52db48ff04c174a8/src/mongoshake/collector/persister_test.go#L36
So `p.enableDiskPersist` will always be false and the `Lock` branch will never be taken.
https://github.com/alibaba/MongoShake/blob/313fc4ebf915324cf6ec793b52db48ff04c174a8/src/mongoshake/collector/persister.go#L52-L53
I suggest changing the configurations to cover the `Lock` branch.

Though unlikely, if leaving out `Unlock` is the intention of the developers (e.g., for misconfiguration detection), I suggest adding error messages and doc to better explain this.