### PR TITLE
fix: close replication metric routine gracefully

### DIFF
--- a/src/mongoshake/collector/docsyncer/doc_syncer.go
+++ b/src/mongoshake/collector/docsyncer/doc_syncer.go
@@ -311,6 +311,8 @@ func (syncer *DBSyncer) Init() {
 func (syncer *DBSyncer) Close() {
 	LOG.Info("syncer[%v] closed", syncer)
 	syncer.replMetric.Close()
+	//sleep 1 second for metric routine exit gracefully
+	time.Sleep(1 * time.Second)
 }
 
 // @deprecated


### PR DESCRIPTION
**Description:**
While in full sync mode, there is a panic in program exiting phase, occasionally.
When diving into code, I find the bug. 
The common/metric.go:startup() function, use a time ticker to report metric periodly. 
When program try to close, the LOG instance is closed immediately after replication metric routine.
But the common/metric.go:startup() function may be still waiting timer timeout in 1 second. 
When timer timeout, this statement will be execute.
`LOG.Info("metric[%v] exit", metric)`
Because LOG instance has been closed, panic occurs.
The error is "send to closed channel"

This is stacktrace

`panic: send on closed channel 
vendor/github.com/vinllen/log4go.(*FileLogWriter).LogWrite(0xc0000beaa0, 0xc000546000)
        /Users/hongmin/project/MongoShake/src/vendor/github.com/vinllen/log4go/filelog.go:45 +0x45
vendor/github.com/vinllen/log4go.Logger.intLogf(0xc00010b8f0, 0x4, 0x4dfa340, 0x19, 0xc000d0be58, 0x2, 0x2)
        /Users/hongmin/project/MongoShake/src/vendor/github.com/vinllen/log4go/log4go.go:223 +0x277
vendor/github.com/vinllen/log4go.Info(0x4c31740, 0x4fb5900, 0xc000d0be58, 0x2, 0x2)
        /Users/hongmin/project/MongoShake/src/vendor/github.com/vinllen/log4go/wrapper.go:195 +0x1cf
mongoshake/collector/doc2essyncer.(*DBSyncer).Start.func2()
        /Users/hongmin/project/MongoShake/src/mongoshake/collector/docsyncer/doc_syncer.go:192 +0xa8f
vendor/github.com/gugemichael/nimo4go.GoRoutine.func1(0xc00038a320)
        /Users/hongmin/project/MongoShake/src/vendor/github.com/gugemichael/nimo4go/runtime.go:12 +0x25
created by vendor/github.com/gugemichael/nimo4go.GoRoutine
        /Users/hongmin/project/MongoShake/src/vendor/github.com/gugemichael/nimo4go/runtime.go:11 +0x3f`


**Fix**
After close replication metric routine, sleep 1 second.

Thanks