### PR TITLE
fix: fix some bugs when syncing indexes

### DIFF
--- a/collector/coordinator/full.go
+++ b/collector/coordinator/full.go
@@ -131,7 +131,7 @@ func (coordinator *ReplicationCoordinator) startDocumentReplication() error {
 	}
 
 	// fetch all indexes
-	var indexMap map[utils.NS][]bson2.M
+	var indexMap map[utils.NS][]bson2.D
 	if conf.Options.FullSyncCreateIndex != utils.VarFullSyncCreateIndexNone {
 		if indexMap, err = fetchIndexes(coordinator.RealSourceFullSync, filterList.IterateFilter); err != nil {
 			return fmt.Errorf("fetch index failed[%v]", err)

--- a/collector/coordinator/utils.go
+++ b/collector/coordinator/utils.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/alibaba/MongoShake/v2/common"
-	"github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/ckpt"
+	"github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/reader"
+	"github.com/alibaba/MongoShake/v2/common"
 
-	"github.com/vinllen/mgo/bson"
 	LOG "github.com/vinllen/log4go"
+	"github.com/vinllen/mgo/bson"
 	bson2 "github.com/vinllen/mongo-go-driver/bson"
 )
 
@@ -188,9 +188,9 @@ func (coordinator *ReplicationCoordinator) selectSyncMode(syncMode string) (stri
  * fetch all indexes.
  * the cost is low so that no need to run in parallel.
  */
-func fetchIndexes(sourceList []*utils.MongoSource, filterFunc func(name string) bool) (map[utils.NS][]bson2.M, error) {
+func fetchIndexes(sourceList []*utils.MongoSource, filterFunc func(name string) bool) (map[utils.NS][]bson2.D, error) {
 	var mutex sync.Mutex
-	indexMap := make(map[utils.NS][]bson2.M)
+	indexMap := make(map[utils.NS][]bson2.D)
 	for _, src := range sourceList {
 		LOG.Info("source[%v %v] start fetching index", src.ReplicaName, utils.BlockMongoUrlPassword(src.URL, "***"))
 		// 1. fetch namespace
@@ -216,7 +216,7 @@ func fetchIndexes(sourceList []*utils.MongoSource, filterFunc func(name string) 
 				return nil, fmt.Errorf("source[%v %v] fetch index failed: %v", src.ReplicaName, src.URL, err)
 			}
 
-			indexes := make([]bson2.M, 0)
+			indexes := make([]bson2.D, 0)
 			if err = cursor.All(nil, &indexes); err != nil {
 				return nil, fmt.Errorf("index cursor fetch all indexes fail: %v", err)
 			}

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -227,8 +227,12 @@ func StartIndexSync(indexMap map[utils.NS][]bson2.D, toUrl string,
 
 				for _, index := range indexNs.indexList {
 					// ignore _id
-					if _, ok := index.Map()["key"].(bson2.D).Map()["_id"]; ok {
-						continue
+					fieldMap := index.Map()["key"].(bson2.D).Map()
+					if _, ok := fieldMap["_id"]; ok {
+						// ignore index that just contain _id field
+						if len(fieldMap) == 1 {
+							continue
+						}
 					}
 					// use bson2.D not bson2.M (Index creation is order sensitive)
 					newIndex := bson2.D{}

--- a/collector/docsyncer/doc_syncer_test.go
+++ b/collector/docsyncer/doc_syncer_test.go
@@ -474,38 +474,53 @@ func TestStartIndexSync(t *testing.T) {
 		err = conn.Client.Database("test_db").Drop(nil)
 		assert.Equal(t, nil, err, "should be equal")
 
-		indexInput := []bson2.M{
+		indexInput := []bson2.D{
 			{
-				"key": bson2.M{
-					"_id": int32(1),
+				{
+					"key", bson2.D{{"_id", int32(1)}},
 				},
-				"name": "_id_",
-				"ns":   "test_db.test_coll",
+				{
+					"name", "_id_",
+				},
+				{
+					"ns", "test_db.test_coll",
+				},
 			},
 			{
-				"key": bson2.M{
-					"hello": "hashed",
+				{
+					"key", bson2.D{{"hello", "hashed"}},
 				},
-				"name": "hello_hashed",
-				"ns":   "test_db.test_coll",
+				{
+					"name", "hello_hashed",
+				},
+				{
+					"ns", "test_db.test_coll",
+				},
 			},
 			{
-				"key": bson2.M{
-					"x": int32(1),
-					"y": int32(1),
+				{
+					"key", bson2.D{{"x", int32(1)}, {"y", int32(1)}},
 				},
-				"name": "x_1_y_1",
-				"ns":   "test_db.test_coll",
+				{
+					"name", "x_1_y_1",
+				},
+				{
+					"ns", "test_db.test_coll",
+				},
 			},
 			{
-				"key": bson2.M{
-					"z": int32(1),
+				{
+					"key", bson2.D{{"z", int32(1)}},
 				},
-				"name": "z_1",
-				"ns":   "test_db.test_coll",
+				{
+					"name", "z_1",
+				},
+				{
+					"ns", "test_db.test_coll",
+				},
 			},
 		}
-		indexMap := map[utils.NS][]bson2.M{
+		indexMap := map[utils.NS][]bson2.D{
 			utils.NS{"test_db", "test_coll"}: indexInput,
 		}
 		err = StartIndexSync(indexMap, testMongoAddress, nil, true)
@@ -514,12 +529,12 @@ func TestStartIndexSync(t *testing.T) {
 		cursor, err := conn.Client.Database("test_db").Collection("test_coll").Indexes().List(nil)
 		assert.Equal(t, nil, err, "should be equal")
 
-		indexes := make([]bson2.M, 0)
+		indexes := make([]bson2.D, 0)
 
 		cursor.All(nil, &indexes)
 		assert.Equal(t, nil, err, "should be equal")
 		assert.Equal(t, len(indexes), len(indexInput), "should be equal")
-		assert.Equal(t, isEqual(indexInput, indexes), true, "should be equal")
+		assert.Equal(t, indexInput, indexes, true, "should be equal")
 	}
 
 	// serverless
@@ -537,38 +552,38 @@ func TestStartIndexSync(t *testing.T) {
 		err = conn.Client.Database("test_db").Drop(nil)
 		assert.Equal(t, nil, err, "should be equal")
 
-		indexInput := []bson2.M{
+		indexInput := []bson2.D{
 			{
-				"key": bson2.M{
-					"_id": int32(1),
+				{
+					"key", bson2.M{"_id": int32(1)},
 				},
-				"name": "_id_",
-				//"ns":   "test_db.test_coll",
 			},
 			{
-				"key": bson2.M{
-					"hello": "hashed",
+				{
+					"key", bson2.D{{"hello", "hashed"}},
 				},
-				"name": "hello_hashed",
-				//"ns":   "test_db.test_coll",
+				{
+					"name", "hello_hashed",
+				},
 			},
 			{
-				"key": bson2.M{
-					"x": int32(1),
-					"y": int32(1),
+				{
+					"key", bson2.D{{"x", int32(1)}, {"y", int32(1)}},
 				},
-				"name": "x_1_y_1",
-				//"ns":   "test_db.test_coll",
+				{
+					"name", "x_1_y_1",
+				},
 			},
 			{
-				"key": bson2.M{
-					"z": int32(1),
+				{
+					"key", bson.D{{"z", int32(1)}},
 				},
-				"name": "z_1",
-				//"ns":   "test_db.test_coll",
+				{
+					"name", "z_1",
+				},
 			},
 		}
-		indexMap := map[utils.NS][]bson2.M{
+		indexMap := map[utils.NS][]bson2.D{
 			utils.NS{"test_db", "test_coll"}: indexInput,
 		}
 		err = StartIndexSync(indexMap, testMongoAddressServerless, nil, true)
@@ -577,12 +592,12 @@ func TestStartIndexSync(t *testing.T) {
 		cursor, err := conn.Client.Database("test_db").Collection("test_coll").Indexes().List(nil)
 		assert.Equal(t, nil, err, "should be equal")
 
-		indexes := make([]bson2.M, 0)
+		indexes := make([]bson2.D, 0)
 
 		cursor.All(nil, &indexes)
 		assert.Equal(t, nil, err, "should be equal")
 		assert.Equal(t, len(indexes), len(indexInput), "should be equal")
-		assert.Equal(t, isEqual(indexInput, indexes), true, "should be equal")
+		assert.Equal(t, indexInput, indexes, true, "should be equal")
 	}
 }
 


### PR DESCRIPTION
1. 修复 包含_id 的复合索引不会被同步的bug
2. 修复复合索引同步顺序不一致的bug