### PR TITLE
fix update election info fail

### DIFF
--- a/quorum/quorum.go
+++ b/quorum/quorum.go
@@ -123,7 +123,7 @@ func BecomeMaster(uri string, db string) error {
 				case STATUS_MASTER:
 					if _, err := masterCollection.UpdateOne(context.Background(),
 						bson.D{{"_id", electionObjectId}, {"pid", os.Getpid()}},
-						promotion()); err == nil {
+						bson.M{"$set": promotion()}); err == nil {
 						masterChanged(PromoteMaster)
 					} else {
 						LOG.Warn("Update master election info failed. %v", err)
@@ -145,7 +145,7 @@ func BecomeMaster(uri string, db string) error {
 					if time.Now().Unix()-heartbeat >= int64(HeartBeatTimeoutInSeconds) {
 						// I wanna be the master. DON'T care about the success of update
 						masterCollection.UpdateOne(context.Background(),
-							bson.D{{"_id", electionObjectId}}, promotion())
+							bson.D{{"_id", electionObjectId}},bson.M{"$set": promotion()})
 						LOG.Info("Expired master found. compete to become master")
 						// wait random time. just disrupt others compete
 						wait(time.Millisecond * time.Duration(rand.Uint32()%2500+1))


### PR DESCRIPTION
修复开启主备模式时更新节点信息报错问题。
报错日志如下：
[{"logger":"default"}] Update master election info failed. update document must contain key beginning with '$'