### PR TITLE
增加skip.nsshardkey配置，可跳过片键的强制校验机制

### DIFF
--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -45,6 +45,7 @@ type Configuration struct {
 	CheckpointStartPosition                int64    `config:"checkpoint.start_position" type:"date"`
 	TransformNamespace                     []string `config:"transform.namespace"`
 	SpecialSourceDBFlag                    string   `config:"special.source.db.flag" type:"string"` // add v2.4.20
+	SkipNSShareKeyVerify                   []string `config:"skip.nsshardkey.verify"`               //add v2.8.2
 
 	// 2. full sync
 	FullSyncReaderCollectionParallel     int    `config:"full_sync.reader.collection_parallel"`

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -316,3 +316,7 @@ incr_sync.executor.majority_enable = false
 
 # 特殊字段，标识源端类型，默认为空。阿里云MongoDB serverless集群请配置aliyun_serverless
 special.source.db.flag =
+
+# 特殊字段，当源库和目标库都是分片集群时，且源表和目标表片键不一致，是否跳过检验
+#例如，db1.collection1;db2.collection2
+skip.nsshardkey.verify =


### PR DESCRIPTION
当源库和目标库都是分片集群时，且源分片集合和目标分片集合片键不一致时，可由用户选择是否跳过检验。

应用场景：
A 集群分片集合S1需要拆分迁移到B 集群，同时又因业务需要调整片键，
可以允许在 B 集群新建 S1分片集合，但片键无需跟A 集群保持一致。