### PR TITLE
add do_not_shard_destination option

### DIFF
--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -85,6 +85,7 @@ type Configuration struct {
 	CheckpointStorage             string `config:"checkpoint.storage"`
 	CheckpointInterval            int64  `config:"checkpoint.interval"`
 	FullSyncExecutorDebug         bool   `config:"full_sync.executor.debug"`
+	FullSyncDoNotShardDest        bool   `config:"full_sync.do_not_shard_destination"`
 	IncrSyncDBRef                 bool   `config:"incr_sync.dbref"`
 	IncrSyncExecutor              int    `config:"incr_sync.executor"`
 	IncrSyncExecutorDebug         bool   `config:"incr_sync.executor.debug"` // !ReplayerDurable

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -31,6 +31,11 @@ func IsShardingToSharding(fromIsSharding bool, toConn *utils.MongoCommunityConn)
 		return false
 	}
 
+	if conf.Options.FullSyncDoNotShardDest {
+		LOG.Info("full_sync.do_not_shard_destination set, no need to check IsShardingToSharding")
+		return false
+	}
+
 	var source, target string
 	if fromIsSharding {
 		source = "sharding"

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -219,6 +219,9 @@ full_sync.collection_exist_drop = true
 # background表示创建后台索引。
 full_sync.create_index = none
 
+# do not make destination collection sharding if source collection is sharding
+full_sync.do_not_shard_destination = false
+
 # convert insert to update when duplicate key found
 # 如果_id存在在目的库，是否将insert语句修改为update语句。
 full_sync.executor.insert_on_dup_update = false


### PR DESCRIPTION
Firstly thanks a lot for the useful tool you built and shared with the world 🙏 

We had a use case where we intended to move a 300GB sharded collection hosted on Mongo Atlas to another regular non-sharded replicaset. Due to the fact that the collection on each shard accidentally had different UUIDs (strange technical quirk of MongoDB) reducing shard number to 0 and then moving it was not possible.

We leveraged **MongoShake** to move all our data. We slightly modified the source code with this flag to skip over the step where the tool shards the destination database/collection to match the configuration of the source.

I thought other people may find it useful too.