### PR TITLE
use replaceOne when full document is available

### DIFF
--- a/oplog/changestram_event.go
+++ b/oplog/changestram_event.go
@@ -220,7 +220,7 @@ func ConvertEvent2Oplog(input []byte, fulldoc bool) (*PartialLog, error) {
 		oplog.Namespace = fmt.Sprintf("%s.%s", ns["db"], ns["coll"])
 		oplog.Operation = "u"
 		oplog.Query = event.DocumentKey
-		oplog.Object = bson.D{{"$set", event.FullDocument}}
+		oplog.Object = event.FullDocument
 	case "update":
 		/*
 		 * mgset-xxx:PRIMARY> db.test.find()
@@ -280,7 +280,7 @@ func ConvertEvent2Oplog(input []byte, fulldoc bool) (*PartialLog, error) {
 		oplog.Query = event.DocumentKey
 
 		if fulldoc && event.FullDocument != nil && len(event.FullDocument) > 0 {
-			oplog.Object = bson.D{{"$set", event.FullDocument}}
+			oplog.Object = event.FullDocument
 		} else {
 			oplog.Object = make(bson.D, 0, 2)
 			if updatedFields, ok := event.UpdateDescription["updatedFields"]; ok && len(updatedFields.(bson.M)) > 0 {


### PR DESCRIPTION
Currently in **change_stream** mode of **incremental** synchronization, while processing the change stream; in those cases that a **FullDocument** is available in an `"u"` (update) or `"r"` (replace) event; MongoShake modifies it to `{ $set: event.FullDocument }` which later in the writing phase will activate this code path

https://github.com/alibaba/MongoShake/blob/develop/executor/db_writer_bulk.go#L132-L164

meaning an `update` query will be used to write to the destination database instead of `replace`. This causes a fatal error as having `_id` in the **event.FullDocument** will fail the update query as MongoDB does not allow modification of the immutable `_id` field. I believe the intended code path when a **FullDocument** is available is in fact the following

https://github.com/alibaba/MongoShake/blob/develop/executor/db_writer_bulk.go#L166-L182

so it makes sense to simply pass **FullDocument** as the object to activate the **replace** code path.