### PR TITLE
for v2.8.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ bin/
 /cmd/collector/collector
 /cmd/receiver/receiver
 conf/
-
-#for unit test
-unit_test_common/include.go

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ bin/
 /cmd/collector/collector
 /cmd/receiver/receiver
 conf/
+common/123.pid

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,23 @@
+2025-12-17 Alibaba Cloud.
+    * version: 2.8.7
+    * FEATURE: add new option incr_sync.executor.bypass_document_validation
+    * BUGFIX: #924, rm useless Mkdirs() in main
+    * BUGFIX: #925, run splitVector failed due to 'Decode to nil value'
+    * BUGFIX: avoid 'ReadConcernMajorityNotEnabled' error in ckptManager for MongoDB3.6-
+    * IMPROVE: log4go support drain remaining log messages
+    * BUGFIX: #928, NamespaceFilter use bson.A instead of []interface{} to handle remainOps
+    * IMPROVE: handle 'update document must contain key beginning with '$'' error
+    * FEATURE: update txn meta to support vectored insert oplog format with 'multiOpType' field
+    * REFINE: change default value of full_sync.create_index to background
+    * FEATURE: PR#820, add kafka SSL support (thanks @renheqiang)
+    * FEATURE: #914, add two shell scripts to print progress/stat (thanks @dobesv)
+    * BUGFIX: #834, init ckptMap correctly with changeStream mode
+    * FEATURE: #926, support mongodb uri with special characters
+    * BUGFIX: #925, run splitVector correctly (thanks @pengzhenyi2015)
+    * IMPROVE: #923, add full_sync.reader.split_max_chunk_size in conf with default 1024MB
+    * IMPROVE: #933, Filter support config.system.preimages
+    * BUGFIX: #897, time-series collections could not use hint (not done)
+
 2025-08-11  Alibaba Cloud.
     * version: 2.8.6
     * BUGFIX: #894, support filter txn oplog with config.system.sessions
@@ -376,7 +396,7 @@
 	* BUG FIX: DDL createIndexes fail. Using `applyOps` in DDL replay. see
 	issue #176.
 	* BUG FIX: DDL filter applyOps command panic.
-	* IMPROVE: improve comparsion script.
+	* IMPROVE: improve comparison script.
 	* IMPROVE: update vinllen/mgo library to solve the problem that using too
 	many mgo connections.
 

--- a/README.md
+++ b/README.md
@@ -100,22 +100,24 @@ We also provide some tools for synchronization in Shake series.<br>
 
 # Thanks
 ---
-| Username | Mail |
-| :------: | :------: |
+| Username |         Mail          |
+| :------: |:---------------------:|
 | lydarkforest | linyunads1379@163.com |
-| diggzhang | diggzhang@gmail.com |
-| ManleyLiu | daywbdb@qq.com |
-| hustchensi | chensi_04@126.com |
-| HelloCodeMing | huanmingwong@163.com |
+| diggzhang |  diggzhang@gmail.com  |
+| ManleyLiu |    daywbdb@qq.com     |
+| hustchensi |   chensi_04@126.com   |
+| HelloCodeMing | huanmingwong@163.com  |
 | cocoakekeyu | cocoakekeyu@gmail.com |
-| lixj1103 | 244769542@qq.com |
-| xzshinan | shinan@gongchang.com |
-| tzjavadmg | codyzeng@163.com |
-| dx8439 | 171390022@qq.com |
-| monkeyWie |  |
-| raydy.yan | yajuyan@hotmail.com |
-| loda507 | 741536172@qq.com |
-| 骑着蜗牛的兔子 | 348978774@qq.com |
-| lijwww | 2530877879@qq.com |
-| nanmu42 | i@nanmu.me |
-| zemul | zemiaozhou@gmail.com |
+| lixj1103 |   244769542@qq.com    |
+| xzshinan | shinan@gongchang.com  |
+| tzjavadmg |   codyzeng@163.com    |
+| dx8439 |   171390022@qq.com    |
+| monkeyWie |                       |
+| raydy.yan |  yajuyan@hotmail.com  |
+| loda507 |   741536172@qq.com    |
+| 骑着蜗牛的兔子 |   348978774@qq.com    |
+| lijwww |   2530877879@qq.com   |
+| nanmu42 |      i@nanmu.me       |
+| zemul | zemiaozhou@gmail.com  |
+| renheqiang |                       |
+| dobesv |   dobesv@gmail.com    |

--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ We also provide some tools for synchronization in Shake series.<br>
 | zemul | zemiaozhou@gmail.com  |
 | renheqiang |                       |
 | dobesv |   dobesv@gmail.com    |
+ | pengzhenyi2015 | 503282373@qq.com |

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -165,7 +165,7 @@ func startup() {
 func selectLeader() {
 	// first of all. ensure we are the Master
 	if conf.Options.MasterQuorum && conf.Options.CheckpointStorage == utils.VarCheckpointStorageDatabase {
-		// election become to Master. keep waiting if we are the candidate. election id is must fixed
+		// election become to Master. keep waiting if we are the candidate. election id must be fixed
 		objectId, _ := primitive.ObjectIDFromHex("5204af979955496907000001")
 		quorum.UseElectionObjectId(objectId)
 		go func() {

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -128,7 +128,7 @@ func startup() {
 	if conf.Options.MongoSUrl != "" {
 		ReplCord.MongoS = &utils.MongoSource{
 			URL:         conf.Options.MongoSUrl,
-			ReplicaName: "mongos",
+			ReplicaName: utils.ReplicaNameMongos,
 		}
 		ReplCord.RealSourceFullSync = []*utils.MongoSource{ReplCord.MongoS}
 		ReplCord.RealSourceIncrSync = []*utils.MongoSource{ReplCord.MongoS}

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -81,7 +81,7 @@ func main() {
 	signalProfile, _ := strconv.Atoi(utils.SIGNALPROFILE)
 	signalStack, _ := strconv.Atoi(utils.SIGNALSTACK)
 	if signalProfile > 0 {
-		nimo.RegisterSignalForProfiling(syscall.Signal(signalProfile))                     // syscall.SIGUSR2
+		nimo.RegisterSignalForProfiling(syscall.Signal(signalProfile)) // syscall.SIGUSR2
 		nimo.RegisterSignalForPrintStack(syscall.Signal(signalStack), func(bytes []byte) { // syscall.SIGUSR1
 			LOG.Info(string(bytes))
 		})
@@ -89,11 +89,6 @@ func main() {
 
 	utils.Welcome()
 
-	err = utils.Mkdirs(conf.Options.LogDirectory)
-	if err != nil {
-		crash(fmt.Sprintf("mkdir log dir failed: %v", err), -5)
-
-	}
 	// get exclusive process lock and write pid
 	if utils.WritePidById(conf.Options.LogDirectory, conf.Options.Id) {
 		if *GCPercent > 0 && *GCPercent <= 100 {

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -92,6 +92,9 @@ func checkDefaultValue() error {
 		conf.Options.LogLevel != utils.VarLogLevelWarning && conf.Options.LogLevel != utils.VarLogLevelError {
 		return fmt.Errorf("log.level should in {debug, info, warning, error}")
 	}
+	if conf.Options.LogDirectory == "" {
+		conf.Options.LogDirectory = "logs"
+	}
 	if conf.Options.LogFileName == "" {
 		conf.Options.LogFileName = "mongoshake.log"
 	}

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -175,7 +175,7 @@ func checkDefaultValue() error {
 		conf.Options.FullSyncReaderFetchBatchSize = 1024
 	}
 	if conf.Options.FullSyncCreateIndex == "" {
-		conf.Options.FullSyncCreateIndex = utils.VarFullSyncCreateIndexForeground
+		conf.Options.FullSyncCreateIndex = utils.VarFullSyncCreateIndexBackground
 	} else if conf.Options.FullSyncCreateIndex != utils.VarFullSyncCreateIndexNone &&
 		conf.Options.FullSyncCreateIndex != utils.VarFullSyncCreateIndexForeground &&
 		conf.Options.FullSyncCreateIndex != utils.VarFullSyncCreateIndexBackground {

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -119,14 +119,15 @@ func checkDefaultValue() error {
 			conf.Options.MongoConnectMode != utils.VarMongoConnectModeSecondary &&
 			conf.Options.MongoConnectMode != utils.VarMongoConnectModeNearset &&
 			conf.Options.MongoConnectMode != utils.VarMongoConnectModeStandalone {
-			return fmt.Errorf("mongo_connect_mode should in {primary, secondaryPreferred, secondary, nearest, standalone}")
+			return fmt.Errorf("mongo_connect_mode should in" +
+				" {primary, secondaryPreferred, secondary, nearest, standalone}")
 		}
 	}
 
 	if conf.Options.IncrSyncMongoFetchMethod == utils.VarIncrSyncMongoFetchMethodChangeStream {
 		if len(conf.Options.MongoSUrl) == 0 && len(conf.Options.MongoUrls) > 1 {
-			return fmt.Errorf("mongo_s_url should be given if source is sharding and incr_sync.mongo_fetch_method == %s",
-				utils.VarIncrSyncMongoFetchMethodChangeStream)
+			return fmt.Errorf("mongo_s_url should be given if source is sharding and "+
+				"incr_sync.mongo_fetch_method == %s", utils.VarIncrSyncMongoFetchMethodChangeStream)
 		}
 	}
 
@@ -200,7 +201,8 @@ func checkDefaultValue() error {
 	}
 	if len(conf.Options.IncrSyncShardByObjectIdWhiteList) != 0 {
 		if conf.Options.IncrSyncShardKey != utils.VarIncrSyncShardKeyCollection {
-			return fmt.Errorf("incr_sync.shard_by_object_id_whitelist should only be set when 'incr_sync.shard_key == collection'")
+			return fmt.Errorf("incr_sync.shard_by_object_id_whitelist should only be set when" +
+				" 'incr_sync.shard_key == collection'")
 		}
 	}
 	if conf.Options.IncrSyncWorker == 0 {
@@ -211,8 +213,8 @@ func checkDefaultValue() error {
 	if conf.Options.IncrSyncTunnelWriteThread == 0 {
 		conf.Options.IncrSyncTunnelWriteThread = conf.Options.IncrSyncWorker
 	} else if conf.Options.IncrSyncTunnelWriteThread%conf.Options.IncrSyncWorker != 0 {
-		return fmt.Errorf("incr_sync.tunnel.write_thread[%v] must be an interge multiple of incr_sync.worker[%v]",
-			conf.Options.IncrSyncTunnelWriteThread, conf.Options.IncrSyncWorker)
+		return fmt.Errorf("incr_sync.tunnel.write_thread[%v] must be an interge multiple of"+
+			" incr_sync.worker[%v]", conf.Options.IncrSyncTunnelWriteThread, conf.Options.IncrSyncWorker)
 	}
 	if conf.Options.IncrSyncWorkerOplogCompressor == "" {
 		conf.Options.IncrSyncWorkerOplogCompressor = utils.VarIncrSyncWorkerOplogCompressorNone
@@ -291,7 +293,8 @@ func checkConnection() error {
 		_, err := utils.NewMongoCommunityConn(mongo, conf.Options.MongoConnectMode, true,
 			utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, conf.Options.MongoSslRootCaFile)
 		if err != nil {
-			return fmt.Errorf("connect source mongodb[%v] failed[%v]", utils.BlockMongoUrlPassword(mongo, "***"), err)
+			return fmt.Errorf("connect source mongodb[%v] failed[%v]",
+				utils.BlockMongoUrlPassword(mongo, "***"), err)
 		}
 	}
 
@@ -300,7 +303,8 @@ func checkConnection() error {
 		_, err := utils.NewMongoCommunityConn(conf.Options.MongoCsUrl, utils.VarMongoConnectModeSecondaryPreferred,
 			true, utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, conf.Options.MongoSslRootCaFile)
 		if err != nil {
-			return fmt.Errorf("connect config-server[%v] failed[%v]", utils.BlockMongoUrlPassword(conf.Options.MongoCsUrl, "***"), err)
+			return fmt.Errorf("connect config-server[%v] failed[%v]",
+				utils.BlockMongoUrlPassword(conf.Options.MongoCsUrl, "***"), err)
 		}
 	}
 
@@ -313,7 +317,8 @@ func checkConnection() error {
 			targetConn, err := utils.NewMongoCommunityConn(mongo, conf.Options.MongoConnectMode, true,
 				utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, conf.Options.TunnelMongoSslRootCaFile)
 			if err != nil {
-				return fmt.Errorf("connect target tunnel mongodb[%v] failed[%v]", utils.BlockMongoUrlPassword(mongo, "***"), err)
+				return fmt.Errorf("connect target tunnel mongodb[%v] failed[%v]",
+					utils.BlockMongoUrlPassword(mongo, "***"), err)
 			}
 
 			// set target version
@@ -333,11 +338,11 @@ func checkConnection() error {
 		utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, conf.Options.MongoSslRootCaFile)
 	// ignore error
 	conf.Options.SourceDBVersion, _ = utils.GetDBVersion(sourceConn)
-	if ok, err := utils.GetAndCompareVersion(sourceConn, "2.6.0",
+	if ok, err := utils.GetAndCompareVersion(sourceConn, utils.MongoVersion26,
 		conf.Options.SourceDBVersion); err != nil {
 		return err
 	} else if !ok {
-		return fmt.Errorf("source MongoDB version[%v] should >= 3.0", conf.Options.SourceDBVersion)
+		return fmt.Errorf("source MongoDB version[%v] should >= 2.6.0", conf.Options.SourceDBVersion)
 	}
 
 	return nil
@@ -392,7 +397,8 @@ func checkConflict() error {
 	}
 	if conf.Options.SpecialSourceDBFlag == utils.VarSpecialSourceDBFlagAliyunServerless {
 		if conf.Options.IncrSyncMongoFetchMethod != utils.VarIncrSyncMongoFetchMethodChangeStream {
-			return fmt.Errorf("incr_sync.mongo_fetch_method must be 'change_stream' when special.source.db.flag is set")
+			return fmt.Errorf("incr_sync.mongo_fetch_method must be 'change_stream' when " +
+				"special.source.db.flag is set")
 		}
 	}
 
@@ -433,7 +439,8 @@ func checkConflict() error {
 	// check source mongodb version >= 4.0 when change stream enable
 	if conf.Options.IncrSyncMongoFetchMethod == utils.VarIncrSyncMongoFetchMethodChangeStream {
 		if conf.Options.MongoSUrl == "" && len(conf.Options.MongoUrls) > 1 {
-			return fmt.Errorf("mongo_s_url should be given when source is sharding and fetch method is change stream")
+			return fmt.Errorf("mongo_s_url should be given when source is sharding and fetch method is" +
+				" change_stream")
 		}
 
 		source, err := getSourceDbUrl()
@@ -444,13 +451,14 @@ func checkConflict() error {
 		conn, err := utils.NewMongoCommunityConn(source, utils.VarMongoConnectModeSecondaryPreferred, true,
 			utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, conf.Options.MongoSslRootCaFile)
 		if err != nil {
-			return fmt.Errorf("connect source[%v] failed[%v]", utils.BlockMongoUrlPassword(source, "***"), err)
+			return fmt.Errorf("connect source[%v] failed[%v]",
+				utils.BlockMongoUrlPassword(source, "***"), err)
 		}
-		if isOk, err := utils.GetAndCompareVersion(conn, "4.0.1", conf.Options.SourceDBVersion); err != nil {
-			return fmt.Errorf("compare source[%v] to v4.0.1 failed[%v]", source, err)
+		if isOk, err := utils.GetAndCompareVersion(conn, utils.MongoVersion401, conf.Options.SourceDBVersion); err != nil {
+			return fmt.Errorf("compare source[%v] to %s failed[%v]", source, utils.MongoVersion401, err)
 		} else if !isOk {
-			return fmt.Errorf("source[%v] version should >= 4.0.1 when incr_sync.mongo_fetch_method == %v",
-				conf.Options.MongoUrls[0], utils.VarIncrSyncMongoFetchMethodChangeStream)
+			return fmt.Errorf("source[%v] version should >= %s when incr_sync.mongo_fetch_method == %v",
+				conf.Options.MongoUrls[0], utils.MongoVersion401, utils.VarIncrSyncMongoFetchMethodChangeStream)
 		}
 	} else {
 		// disable mongos if fetch method != 'change_stream'

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -168,6 +168,13 @@ func checkDefaultValue() error {
 	if conf.Options.FullSyncReaderParallelIndex == "" {
 		conf.Options.FullSyncReaderParallelIndex = "_id"
 	}
+	if conf.Options.FullSyncReaderSplitMaxChunkSize == 0 {
+		conf.Options.FullSyncReaderSplitMaxChunkSize = 1024
+	}
+	if conf.Options.FullSyncReaderSplitMaxChunkSize < 1 {
+		return fmt.Errorf("full_sync.reader.split_max_chunk_size should >= 1, " +
+			"and for some minor versions, should be within [1, 1024]MB")
+	}
 	if conf.Options.FullSyncReaderDocumentBatchSize <= 0 {
 		conf.Options.FullSyncReaderDocumentBatchSize = 128
 	}

--- a/collector/batcher_test.go
+++ b/collector/batcher_test.go
@@ -30,17 +30,6 @@ func mockSyncer() *OplogSyncer {
 	return syncer
 }
 
-func marshalData(input bson.D) bson.Raw {
-	var dataRaw bson.Raw
-	if data, err := bson.Marshal(input); err != nil {
-		return nil
-	} else {
-		dataRaw = data[:]
-	}
-
-	return dataRaw
-}
-
 /*
  * return oplogs array with length=input length.
  * ddlGiven array marks the ddl.
@@ -69,7 +58,7 @@ func mockOplogs(length int, ddlGiven []int, noopGiven []int, txnGiven []int, sta
 					Operation: op,
 					Timestamp: utils.TimeToTimestamp(startTs + int64(i)),
 					TxnNumber: &txnN[0],
-					LSID: marshalData(bson.D{
+					LSID: utils.MarshalData(bson.D{
 						{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, 7}}},
 						{"uid", []byte{9, 8, 7, 6, 5, 4, 3, 2, 1}},
 					}),
@@ -130,13 +119,13 @@ func mockOplogs(length int, ddlGiven []int, noopGiven []int, txnGiven []int, sta
 								},
 							},
 						},
-						LSID: marshalData(
+						LSID: utils.MarshalData(
 							bson.D{
 								{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, byte(startTs + int64(i))}}},
 								{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs + int64(i))}},
 							}),
 						TxnNumber:  &txnN[0],
-						PrevOpTime: marshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+						PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
 					},
 				},
 			}
@@ -215,13 +204,13 @@ func mockTxnPartialOplogs(startTs int64, normalOplog bool) []*oplog.GenericOplog
 						Value: interface{}(true),
 					},
 				},
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{Subtype: 4, Data: []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
 			},
 		},
 	}
@@ -282,13 +271,13 @@ func mockTxnPartialOplogs(startTs int64, normalOplog bool) []*oplog.GenericOplog
 						Value: interface{}(true),
 					},
 				},
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{Subtype: 4, Data: []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 0)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 0)}}),
 			},
 		},
 	}
@@ -367,13 +356,13 @@ func mockTxnPartialOplogs(startTs int64, normalOplog bool) []*oplog.GenericOplog
 						Value: interface{}(9),
 					},
 				},
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{Subtype: 4, Data: []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 1)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 1)}}),
 			},
 		},
 	}
@@ -445,13 +434,13 @@ func mockDisTxnOplogs(startTs int64, normalOplog bool, isCommit bool) []*oplog.G
 						Value: interface{}(true),
 					},
 				},
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
 			},
 		},
 	}
@@ -501,13 +490,13 @@ func mockDisTxnOplogs(startTs int64, normalOplog bool, isCommit bool) []*oplog.G
 				Operation: "c",
 				Namespace: "admin.$cmd",
 				Object:    tmpO,
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 0)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 0)}}),
 			},
 		},
 	}
@@ -579,13 +568,13 @@ func mockDisTxnPartialOplogs(startTs int64, normalOplog bool, isCommit bool) []*
 						Value: interface{}(true),
 					},
 				},
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
 			},
 		},
 	}
@@ -646,13 +635,13 @@ func mockDisTxnPartialOplogs(startTs int64, normalOplog bool, isCommit bool) []*
 						Value: interface{}(true),
 					},
 				},
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 0)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 0)}}),
 			},
 		},
 	}
@@ -702,13 +691,13 @@ func mockDisTxnPartialOplogs(startTs int64, normalOplog bool, isCommit bool) []*
 				Operation: "c",
 				Namespace: "admin.$cmd",
 				Object:    tmpO,
-				LSID: marshalData(
+				LSID: utils.MarshalData(
 					bson.D{
 						{"id", primitive.Binary{4, []byte{0, 1, 3, 4, 5, 6, byte(startTs)}}},
 						{"uid", []byte{8, 7, 6, 5, 4, 3, 2, 1, byte(startTs)}},
 					}),
 				TxnNumber:  &txnN[0],
-				PrevOpTime: marshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 1)}}),
+				PrevOpTime: utils.MarshalData(bson.D{{"ts", utils.TimeToTimestamp(startTs + 1)}}),
 			},
 		},
 	}

--- a/collector/ckpt/ckpt_manager.go
+++ b/collector/ckpt/ckpt_manager.go
@@ -56,7 +56,7 @@ func NewCheckpointManager(name string, startPosition int64) *CheckpointManager {
 	return newManager
 }
 
-// get persist checkpoint
+// Get return persistent checkpoint
 func (manager *CheckpointManager) Get() (*CheckpointContext, bool, error) {
 	var exist bool
 	manager.ctx, exist = manager.delegate.Get()
@@ -66,7 +66,8 @@ func (manager *CheckpointManager) Get() (*CheckpointContext, bool, error) {
 
 	// check fcv
 	if exist && utils.FcvCheckpoint.IsCompatible(manager.ctx.Version) == false {
-		return nil, exist, fmt.Errorf("current required checkpoint version[%v] > input[%v], please upgrade MongoShake to version >= %v",
+		return nil, exist, fmt.Errorf("current required checkpoint version[%v] > input[%v],"+
+			" please upgrade MongoShake to version >= %v",
 			utils.FcvCheckpoint.CurrentVersion, manager.ctx.Version,
 			utils.LowestCheckpointVersion[utils.FcvCheckpoint.CurrentVersion])
 	}
@@ -74,7 +75,7 @@ func (manager *CheckpointManager) Get() (*CheckpointContext, bool, error) {
 	return manager.ctx, exist, nil
 }
 
-// get in memory checkpoint
+// GetInMemory return in-memory checkpoint
 func (manager *CheckpointManager) GetInMemory() *CheckpointContext {
 	return manager.ctx
 }
@@ -105,7 +106,8 @@ func (manager *CheckpointManager) Update(ts int64) error {
 	return manager.delegate.Insert(manager.ctx)
 }
 
-// OplogDiskQueueFinishTs and OplogDiskQueue won't immediate effect, will be inserted in the next Update call.
+// SetOplogDiskFinishTs
+// OplogDiskQueueFinishTs and OplogDiskQueue won't take effect immediately, will be inserted in the next Update call.
 func (manager *CheckpointManager) SetOplogDiskFinishTs(ts int64) {
 	if manager.ctxRec == nil {
 		manager.ctxRecLock.Lock()

--- a/collector/ckpt/ckpt_operation.go
+++ b/collector/ckpt/ckpt_operation.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/Masterminds/semver/v3"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -17,7 +18,8 @@ import (
 )
 
 const (
-	// we can't insert Timestamp(0, 0) that will be treat as Now() inserted
+	// InitCheckpoint
+	// Note: we can't insert Timestamp(0, 0) that will be treat as Now() inserted
 	// into mongo. so we use Timestamp(0, 1)
 	InitCheckpoint  = int64(1)
 	EmptyCheckpoint = int64(0)
@@ -41,19 +43,19 @@ func (cc *CheckpointContext) String() string {
 }
 
 type CheckpointOperation interface {
-	// read checkpoint from remote storage. and encapsulation
+	// Get read checkpoint from remote storage. and encapsulation
 	// with CheckpointContext struct
 	// bool means whether exists on remote
 	Get() (*CheckpointContext, bool)
 
-	// save checkpoint
+	// Insert save checkpoint
 	Insert(ckpt *CheckpointContext) error
 
-	// log info
+	// String return log info
 	String() string
 }
 
-// mongo
+// MongoCheckpoint for mongo
 type MongoCheckpoint struct {
 	CheckpointContext
 
@@ -66,13 +68,41 @@ type MongoCheckpoint struct {
 
 func (ckpt *MongoCheckpoint) ensureNetwork() bool {
 	if ckpt.client == nil {
+		// mongodb3.6- doesn't support {readConcern:majority}, here we use 'local' first to get dbVersion,
+		// then change to 'majority' if possible.
+		tmpClient, err := utils.NewMongoCommunityConn(ckpt.URL, utils.VarMongoConnectModePrimary, true, "local", "", "")
+		if err != nil {
+			LOG.Error("%s MongoCheckpoint create client failed:%v", ckpt.Name, err)
+			return false
+		}
+		defer tmpClient.Close()
+		dbVersion, err := utils.GetDBVersion(tmpClient)
+		if err != nil {
+			LOG.Error("%s MongoCheckpoint get db version failed:%v", ckpt.Name, err)
+			return false
+		}
+		version, err := semver.StrictNewVersion(dbVersion)
+		if err != nil {
+			LOG.Error("%s MongoCheckpoint failed to parse dbVersion: %v", ckpt.Name, err)
+			return false
+		}
+		version36, _ := semver.StrictNewVersion(utils.MongoVersion36)
+		rc := utils.ReadWriteConcernLocal
+		if version.GreaterThanEqual(version36) {
+			LOG.Info("%s MongoCheckpoint dbVersion %s >= %s, use readConcern:majority",
+				ckpt.Name, version.String(), utils.MongoVersion36)
+			rc = utils.ReadWriteConcernMajority
+		} else {
+			LOG.Info("%s MongoCheckpoint dbVersion %s < %s, use readConcern:local",
+				ckpt.Name, version.String(), utils.MongoVersion36)
+		}
+
 		if client, err := utils.NewMongoCommunityConn(ckpt.URL, utils.VarMongoConnectModePrimary, true,
-			utils.ReadWriteConcernMajority, utils.ReadWriteConcernMajority,
+			rc, utils.ReadWriteConcernMajority,
 			conf.Options.CheckpointStorageUrlMongoSslRootCaFile); err == nil {
 			ckpt.client = client
-
 		} else {
-			LOG.Warn("%s CheckpointOperation manager connect mongo cluster failed. %v", ckpt.Name, err)
+			LOG.Error("%s MongoCheckpoint connect to mongo cluster failed. %v", ckpt.Name, err)
 			return false
 		}
 	}
@@ -87,7 +117,7 @@ func (ckpt *MongoCheckpoint) close() {
 
 func (ckpt *MongoCheckpoint) Get() (*CheckpointContext, bool) {
 	if !ckpt.ensureNetwork() {
-		LOG.Warn("%s Reload ckpt ensure network failed. %v", ckpt.Name, ckpt.client)
+		LOG.Error("%s MongoCheckpoint ensureNetwork failed", ckpt.Name)
 		return nil, false
 	}
 
@@ -98,7 +128,7 @@ func (ckpt *MongoCheckpoint) Get() (*CheckpointContext, bool) {
 
 		LOG.Info("%s Load exist checkpoint. content %v", ckpt.Name, value)
 		return value, true
-	} else if err == mongo.ErrNoDocuments {
+	} else if err.Error() == mongo.ErrNoDocuments.Error() {
 		if InitCheckpoint > ckpt.Timestamp {
 			ckpt.Timestamp = InitCheckpoint
 		}
@@ -138,7 +168,7 @@ func (ckpt *MongoCheckpoint) Insert(updates *CheckpointContext) error {
 	return nil
 }
 
-// http
+// HttpApiCheckpoint for http api
 type HttpApiCheckpoint struct {
 	CheckpointContext
 
@@ -175,11 +205,13 @@ func (ckpt *HttpApiCheckpoint) Get() (*CheckpointContext, bool) {
 
 func (ckpt *HttpApiCheckpoint) Insert(insert *CheckpointContext) error {
 	body, _ := json.Marshal(insert)
-	if resp, err := http.Post(ckpt.URL, "application/json", bytes.NewReader(body)); err != nil || resp.StatusCode != http.StatusOK {
+	if resp, err := http.Post(ckpt.URL, "application/json", bytes.NewReader(body));
+		err != nil || resp.StatusCode != http.StatusOK {
 		LOG.Warn("%s Context api manager write request failed, %v", ckpt.Name, err)
 		return err
 	}
 
-	LOG.Info("%s Record new checkpoint in HttpApi success [%d]", ckpt.Name, utils.ExtractMongoTimestamp(insert.Timestamp))
+	LOG.Info("%s Record new checkpoint in HttpApi success [%d]",
+		ckpt.Name, utils.ExtractMongoTimestamp(insert.Timestamp))
 	return nil
 }

--- a/collector/configure/check.go
+++ b/collector/configure/check.go
@@ -10,7 +10,7 @@ import (
 	utils "github.com/alibaba/MongoShake/v2/common"
 )
 
-// read the given file and parse the fcv do comparison
+// CheckFcv read the given file and parse the fcv do comparison
 func CheckFcv(file string, fcv int) (int, error) {
 	// read line by line and parse the version
 

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -81,6 +81,7 @@ type Configuration struct {
 	IncrSyncExecutorInsertOnDupUpdate      bool     `config:"incr_sync.executor.insert_on_dup_update"`
 	IncrSyncConflictWriteTo                string   `config:"incr_sync.conflict_write_to"` // remove "sdk" option since v2.4.21
 	IncrSyncExecutorMajorityEnable         bool     `config:"incr_sync.executor.majority_enable"`
+	IncrSyncBypassDocumentValidation       bool     `config:"incr_sync.executor.bypass_document_validation"` // add v2.8.7
 
 	/*---------------------------------------------------------*/
 	// inner variables, not open to user

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -30,7 +30,12 @@ type Configuration struct {
 	Tunnel                                 string   `config:"tunnel"`
 	TunnelAddress                          []string `config:"tunnel.address"`
 	TunnelMessage                          string   `config:"tunnel.message"`
-	TunnelKafkaPartitionNumber             int      `config:"tunnel.kafka.partition_number"` // add v2.4.21
+	TunnelKafkaPartitionNumber             int      `config:"tunnel.kafka.partition_number"`           // add v2.4.21
+	TunnelKafkaSaslEnable                  bool     `config:"tunnel.kafka.sasl.enable"`                // add v2.8.7
+	TunnelKafkaSaslAuth                    string   `config:"tunnel.kafka.sasl.auth"`                  // add v2.8.7
+	TunnelKafkaSaslMechanism               string   `config:"tunnel.kafka.sasl.mechanism"`             // add v2.8.7
+	TunnelKafkaCompression                 string   `config:"tunnel.kafka.compression"`                // add v2.8.7
+	KafkaProducerMaxMessage                int      `config:"tunnel.kafka.producer.max_message_bytes"` // add v2.8.7
 	TunnelJsonFormat                       string   `config:"tunnel.json.format"`
 	TunnelMongoSslRootCaFile               string   `config:"tunnel.mongo_ssl_root_ca_file"` // add v2.6.2
 	FilterNamespaceBlack                   []string `config:"filter.namespace.black"`
@@ -141,6 +146,7 @@ func GetSafeOptions() Configuration {
 	for i := range Options.IncrSyncTunnelAddress {
 		polish.IncrSyncTunnelAddress[i] = utils.BlockMongoUrlPassword(Options.IncrSyncTunnelAddress[i], "***")
 	}
+	polish.TunnelKafkaSaslAuth = utils.BlockMongoUrlPassword(Options.TunnelKafkaSaslAuth, "***")
 	// modify storage url
 	polish.CheckpointStorageUrl = utils.BlockMongoUrlPassword(Options.CheckpointStorageUrl, "***")
 

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -57,8 +57,9 @@ type Configuration struct {
 	FullSyncReaderWriteDocumentParallel  int    `config:"full_sync.reader.write_document_parallel"`
 	FullSyncReaderDocumentBatchSize      int    `config:"full_sync.reader.document_batch_size"`
 	FullSyncReaderFetchBatchSize         int    `config:"full_sync.reader.fetch_batch_size"`
-	FullSyncReaderParallelThread         int    `config:"full_sync.reader.parallel_thread"` // add v2.6.4
-	FullSyncReaderParallelIndex          string `config:"full_sync.reader.parallel_index"`  // add v2.6.4
+	FullSyncReaderParallelThread         int    `config:"full_sync.reader.parallel_thread"`      // add v2.6.4
+	FullSyncReaderParallelIndex          string `config:"full_sync.reader.parallel_index"`       // add v2.6.4
+	FullSyncReaderSplitMaxChunkSize      int    `config:"full_sync.reader.split_max_chunk_size"` // add v2.8.7
 	FullSyncCollectionDrop               bool   `config:"full_sync.collection_exist_drop"`
 	FullSyncCreateIndex                  string `config:"full_sync.create_index"`
 	FullSyncReaderOplogStoreDisk         bool   `config:"full_sync.reader.oplog_store_disk"`

--- a/collector/coordinator/full.go
+++ b/collector/coordinator/full.go
@@ -85,10 +85,12 @@ func (coordinator *ReplicationCoordinator) startDocumentReplication() error {
 	}
 	LOG.Info("all namespace: %v", nsSet)
 
+	// init ckptMap with source of full sync, no matter mongod or mongos
 	var ckptMap map[string]utils.TimestampNode
-	if conf.Options.SpecialSourceDBFlag != utils.VarSpecialSourceDBFlagAliyunServerless && len(coordinator.MongoD) > 0 {
+	if conf.Options.SpecialSourceDBFlag != utils.VarSpecialSourceDBFlagAliyunServerless &&
+		(len(coordinator.RealSourceFullSync) > 0) {
 		// get current newest timestamp
-		ckptMap, err = getTimestampMap(coordinator.MongoD, conf.Options.MongoSslRootCaFile)
+		ckptMap, err = getTimestampMap(coordinator.RealSourceFullSync, conf.Options.MongoSslRootCaFile)
 		if err != nil {
 			return err
 		}

--- a/collector/docsyncer/doc_reader.go
+++ b/collector/docsyncer/doc_reader.go
@@ -63,10 +63,11 @@ func NewDocumentSplitter(src, sslRootCaFile string, ns utils.NS) *DocumentSplitt
 		return nil
 	}
 	ds.count = uint64(res.Count)
+	// max pieceByteSize should be limited by maxChunkSize of splitVector cmd
 	ds.pieceByteSize = uint64(res.Size / float64(conf.Options.FullSyncReaderParallelThread))
-	if ds.pieceByteSize > 8*utils.GB {
+	if ds.pieceByteSize > 1024*utils.MB {
 		// at most 8GB per chunk
-		ds.pieceByteSize = 8 * utils.GB
+		ds.pieceByteSize = 1024 * utils.MB
 	}
 
 	LOG.Info("NewDocumentSplitter db[%v] col[%v] res[%v], pieceByteSize[%v]",
@@ -107,15 +108,20 @@ func (ds *DocumentSplitter) Run() error {
 		return nil
 	}
 
-	LOG.Info("splitter[%s] enable split, waiting splitVector return...", ds)
+	maxChunkSize := conf.Options.FullSyncReaderSplitMaxChunkSize // default 1024MB, could be set by user
+	if uint64(maxChunkSize*utils.MB) > ds.pieceByteSize {
+		maxChunkSize = int(ds.pieceByteSize / uint64(utils.MB))
+	}
+	splitVectorCmd := bson.D{
+		{"splitVector", ds.ns.Str()},
+		{"keyPattern", bson.M{conf.Options.FullSyncReaderParallelIndex: 1}}, // {_id:1} or {shardKey:1}
+		// {"maxSplitPoints", ds.pieceNumber - 1},
+		{"maxChunkSize", maxChunkSize},
+	}
+	LOG.Info("splitter[%s] splitVector cmd: %v, waiting splitVector return...", ds, splitVectorCmd)
 
 	res := SplitVectorResult{}
-	err := ds.client.Client.Database(ds.ns.Database).RunCommand(context.Background(), bson.D{
-		{"splitVector", ds.ns.Str()},
-		{"keyPattern", bson.M{conf.Options.FullSyncReaderParallelIndex: 1}},
-		// {"maxSplitPoints", ds.pieceNumber - 1},
-		{"maxChunkSize", ds.pieceByteSize / utils.MB},
-	}).Decode(&res)
+	err := ds.client.Client.Database(ds.ns.Database).RunCommand(context.Background(), splitVectorCmd).Decode(&res)
 	// if failed, do not panic, run single thread fetching
 	if err != nil {
 		LOG.Warn("splitter[%s] run splitVector failed[%v], give up parallel fetching", ds, err)

--- a/collector/docsyncer/doc_reader.go
+++ b/collector/docsyncer/doc_reader.go
@@ -26,6 +26,11 @@ type DocumentSplitter struct {
 	pieceNumber   int                  // how many piece
 }
 
+// SplitVectorResult is the result of splitVector cmd, contains multi split points.
+type SplitVectorResult struct {
+	SplitKeys []bson.Raw `bson:"splitKeys"`
+}
+
 func NewDocumentSplitter(src, sslRootCaFile string, ns utils.NS) *DocumentSplitter {
 	ds := &DocumentSplitter{
 		src:           src,
@@ -104,7 +109,7 @@ func (ds *DocumentSplitter) Run() error {
 
 	LOG.Info("splitter[%s] enable split, waiting splitVector return...", ds)
 
-	res := bson.M{}
+	res := SplitVectorResult{}
 	err := ds.client.Client.Database(ds.ns.Database).RunCommand(context.Background(), bson.D{
 		{"splitVector", ds.ns.Str()},
 		{"keyPattern", bson.M{conf.Options.FullSyncReaderParallelIndex: 1}},
@@ -118,46 +123,51 @@ func (ds *DocumentSplitter) Run() error {
 		LOG.Info("splitter[%s] exits", ds)
 		return nil
 	}
+	// only print if len(splitKeys) < 100
+	if len(res.SplitKeys) > 100 {
+		LOG.Info("splitter[%s] run splitVector result len(splitKeys): %v", ds, len(res.SplitKeys))
+	} else {
+		LOG.Info("splitter[%s] run splitVector result splitKeys: %v", ds, res)
+	}
 
-	LOG.Info("splitter[%s] run splitVector result: %v", ds, res)
+	if len(res.SplitKeys) > 0 {
+		// return list is sorted
+		ds.pieceNumber = len(res.SplitKeys) + 1
 
-	if splitKeys, ok := res["splitKeys"]; ok {
-		if splitKeysList, ok := splitKeys.([]interface{}); ok && len(splitKeysList) > 0 {
-			// return list is sorted
-			ds.pieceNumber = len(splitKeysList) + 1
-
-			var start interface{}
-			cnt := 0
-			for i, keyDoc := range splitKeysList {
-				// check key == conf.Options.FullSyncReaderParallelIndex
-				key, val, err := parseDocKeyValue(keyDoc)
-				if err != nil {
-					LOG.Crash("splitter[%s] parse doc key failed: %v", ds, err)
-				}
-				if key != conf.Options.FullSyncReaderParallelIndex {
-					LOG.Crash("splitter[%s] parse doc invalid key: %v", ds, key)
-				}
-
-				LOG.Info("splitter[%s] piece[%d] create reader with boundary(%v, %v]", ds, cnt, start, val)
-				// inject new DocumentReader into channel
-				ds.readerChan <- NewDocumentReader(cnt, ds.src, ds.ns, key, start, val, ds.sslRootCaFile)
-
-				// new start
-				start = val
-				cnt++
-
-				// last one
-				if i == len(splitKeysList)-1 {
-					LOG.Info("splitter[%s] piece[%d] create reader with boundary(%v, INF)", ds, cnt, start)
-					// inject new DocumentReader into channel
-					ds.readerChan <- NewDocumentReader(cnt, ds.src, ds.ns, key, start, nil, ds.sslRootCaFile)
-				}
+		var start interface{}
+		cnt := 0
+		for i, keyDoc := range res.SplitKeys {
+			// check key == conf.Options.FullSyncReaderParallelIndex
+			doc := bson.M{}
+			err := bson.Unmarshal(keyDoc, &doc)
+			if err != nil {
+				LOG.Crash("splitter[%s] unmarshal doc [%v] failed: %v", ds, keyDoc, err)
+			}
+			key, val, err := parseDocKeyValue(doc)
+			if err != nil {
+				LOG.Crash("splitter[%s] parse doc key failed: %v", ds, err)
+			}
+			if key != conf.Options.FullSyncReaderParallelIndex {
+				LOG.Crash("splitter[%s] parse doc invalid key: %v", ds, key)
 			}
 
-			return nil
-		} else {
-			LOG.Warn("splitter[%s] run splitVector return empty result[%v]", ds, res)
+			LOG.Info("splitter[%s] piece[%d] create reader with boundary(%v, %v]", ds, cnt, start, val)
+			// inject new DocumentReader into channel
+			ds.readerChan <- NewDocumentReader(cnt, ds.src, ds.ns, key, start, val, ds.sslRootCaFile)
+
+			// new start
+			start = val
+			cnt++
+
+			// last one
+			if i == len(res.SplitKeys)-1 {
+				LOG.Info("splitter[%s] piece[%d] create reader with boundary(%v, INF)", ds, cnt, start)
+				// inject new DocumentReader into channel
+				ds.readerChan <- NewDocumentReader(cnt, ds.src, ds.ns, key, start, nil, ds.sslRootCaFile)
+			}
 		}
+
+		return nil
 	} else {
 		LOG.Warn("splitter[%s] run splitVector return null result[%v]", ds, res)
 	}

--- a/collector/docsyncer/doc_reader.go
+++ b/collector/docsyncer/doc_reader.go
@@ -14,8 +14,7 @@ import (
 	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
 )
 
-/*************************************************/
-// splitter: pre-split the collection into several pieces
+// DocumentSplitter pre-split the big collection into several pieces
 type DocumentSplitter struct {
 	src           string   // source mongo address url
 	sslRootCaFile string   // source root ca ssl
@@ -91,7 +90,6 @@ func (ds *DocumentSplitter) String() string {
 		utils.BlockMongoUrlPassword(ds.src, "***"), ds.ns, ds.count, ds.pieceByteSize/utils.MB, ds.pieceNumber)
 }
 
-// TODO, need add retry
 func (ds *DocumentSplitter) Run() error {
 	// close channel
 	defer close(ds.readerChan)
@@ -106,13 +104,13 @@ func (ds *DocumentSplitter) Run() error {
 
 	LOG.Info("splitter[%s] enable split, waiting splitVector return...", ds)
 
-	var res bson.M
-	err := ds.client.Client.Database(ds.ns.Database).RunCommand(nil, bson.D{
+	res := bson.M{}
+	err := ds.client.Client.Database(ds.ns.Database).RunCommand(context.Background(), bson.D{
 		{"splitVector", ds.ns.Str()},
 		{"keyPattern", bson.M{conf.Options.FullSyncReaderParallelIndex: 1}},
 		// {"maxSplitPoints", ds.pieceNumber - 1},
 		{"maxChunkSize", ds.pieceByteSize / utils.MB},
-	}).Decode(res)
+	}).Decode(&res)
 	// if failed, do not panic, run single thread fetching
 	if err != nil {
 		LOG.Warn("splitter[%s] run splitVector failed[%v], give up parallel fetching", ds, err)
@@ -184,8 +182,7 @@ func parseDocKeyValue(x interface{}) (string, interface{}, error) {
 	return key, val, nil
 }
 
-/*************************************************/
-// DocumentReader: the reader of single piece
+// DocumentReader is the reader for single piece
 type DocumentReader struct {
 	// source mongo address url
 	src           string
@@ -206,7 +203,8 @@ type DocumentReader struct {
 }
 
 // NewDocumentReader creates reader with mongodb url
-func NewDocumentReader(id int, src string, ns utils.NS, key string, start, end interface{}, sslRootCaFile string) *DocumentReader {
+func NewDocumentReader(id int, src string, ns utils.NS, key string, start, end interface{},
+	sslRootCaFile string) *DocumentReader {
 	q := make(bson.M)
 	if start != nil || end != nil {
 		innerQ := make(bson.M)
@@ -241,7 +239,7 @@ func (reader *DocumentReader) String() string {
 	return ret
 }
 
-// NextDoc returns an document by raw bytes which is []byte
+// NextDoc returns a document by raw bytes which is []byte
 // reader.docCursor.Current is valid only before next docCursor.Next(), So must be copy
 func (reader *DocumentReader) NextDoc() (doc bson.Raw, err error) {
 	if err := reader.ensureNetwork(); err != nil {

--- a/collector/docsyncer/doc_reader.go
+++ b/collector/docsyncer/doc_reader.go
@@ -311,6 +311,8 @@ func (reader *DocumentReader) ensureNetwork() (err error) {
 	// enable noCursorTimeout anyway! #451 #784
 	if reader.client.IsTimeSeriesCollection(reader.ns.Database, reader.ns.Collection) == false {
 		findOptions.SetNoCursorTimeout(true)
+		// timeseries collections can't use hint since they do not have _id index, #897
+		findOptions.SetHint(nil)
 	}
 	findOptions.SetComment(fmt.Sprintf("mongo-shake full sync: ns[%v] query[%v] rebuid-times[%v]",
 		reader.ns, reader.query, reader.rebuild))

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -247,8 +247,9 @@ func StartIndexSync(indexMap map[utils.NS][]bson.D, toUrl string,
 		nimo.GoRoutine(func() {
 			var conn *utils.MongoCommunityConn
 			var err error
-			if conn, err = utils.NewMongoCommunityConn(toUrl, utils.VarMongoConnectModePrimary, true,
-				utils.ReadWriteConcernLocal, utils.ReadWriteConcernMajority, conf.Options.TunnelMongoSslRootCaFile); err != nil {
+			conn, err = utils.NewMongoCommunityConn(toUrl, utils.VarMongoConnectModePrimary, true,
+				utils.ReadWriteConcernLocal, utils.ReadWriteConcernMajority, conf.Options.TunnelMongoSslRootCaFile)
+			if err != nil {
 				_ = LOG.Error("write index but create client fail: %v", err)
 				return
 			}

--- a/collector/filter/doc_filter.go
+++ b/collector/filter/doc_filter.go
@@ -24,6 +24,9 @@ var NsShouldBeIgnore = map[string]bool{
 	"config.mongos":                   true,
 	"config.system.sessions":          true,
 	"config.system.indexBuilds":       true,
+	"config.system.preimages":         true,
+	"config.migrationCoordinators":    true,
+	"config.rangeDeletions":           true,
 	//"system.views":                    false,
 	"system.profile": false,
 }

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -133,7 +133,7 @@ func TestNamespaceFilter(t *testing.T) {
 			},
 		}
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
-		assert.Equal(t, 2, len(log.Object[0].Value.([]interface{})), "should be equal")
+		assert.Equal(t, 2, len(log.Object[0].Value.(bson.A)), "should be equal")
 	}
 
 	{
@@ -171,7 +171,7 @@ func TestNamespaceFilter(t *testing.T) {
 			},
 		}
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
-		assert.Equal(t, 1, len(log.Object[0].Value.([]interface{})), "should be equal")
+		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
 	}
 
 	{
@@ -209,7 +209,7 @@ func TestNamespaceFilter(t *testing.T) {
 			},
 		}
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
-		assert.Equal(t, 1, len(log.Object[0].Value.([]interface{})), "should be equal")
+		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
 	}
 }
 

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -3,12 +3,16 @@ package filter
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/getlantern/deepcopy"
+	"github.com/mongodb/mongo-tools-common/json"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 
+	utils "github.com/alibaba/MongoShake/v2/common"
 	"github.com/alibaba/MongoShake/v2/oplog"
 )
 
@@ -97,12 +101,12 @@ func TestNamespaceFilter(t *testing.T) {
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
 	}
 
-	// test applyOps
+	// applyOps
 	{
 		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
 		nr++
 
-		filter := NewNamespaceFilter(nil, nil)
+		filter := NewNamespaceFilter([]string{"zz"}, nil)
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
 				Namespace: "admin.$cmd",
@@ -134,8 +138,40 @@ func TestNamespaceFilter(t *testing.T) {
 		}
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
 		assert.Equal(t, 2, len(log.Object[0].Value.(bson.A)), "should be equal")
+
+		log1 := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key: "applyOps",
+						Value: []bson.D{
+							{
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ns", Value: "zl.mmm"},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "a", Value: 1},
+									bson.E{Key: "_id", Value: "xxx"},
+								}},
+							},
+							{
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ns", Value: "zl.x"},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "xyz", Value: "ff"},
+									bson.E{Key: "_id", Value: "yyy"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log1), "should be equal")
 	}
 
+	// applyOps with black list and rewrite 'o.applyOps' field
 	{
 		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
 		nr++
@@ -210,6 +246,151 @@ func TestNamespaceFilter(t *testing.T) {
 		}
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
 		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
+
+	// applyOps with delete op for config.system.sessions
+	// NamespaceFilter will not handle it, it's handled by AutologousFilter
+	{
+		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
+		nr++
+		filter := NewNamespaceFilter(nil, nil)
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key: "applyOps",
+						Value: []bson.D{
+							{
+								bson.E{Key: "op", Value: "d"},
+								bson.E{Key: "ns", Value: "config.system.sessions"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: "xxx"},
+								}},
+							},
+							{
+								bson.E{Key: "op", Value: "d"},
+								bson.E{Key: "ns", Value: "config.system.sessions"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: "yyy"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 2, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
+	// applyOps with {multiOpType:1}
+	{
+		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
+		nr++
+		filter := NewNamespaceFilter([]string{"zz"}, nil)
+		txnN := []int64{0, 1}
+		term := []int64{1}
+		multiOpType := []int{0, 1}
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				TxnNumber: &txnN[0],
+				Object: bson.D{
+					bson.E{
+						Key: "applyOps",
+						Value: []bson.D{
+							{
+								bson.E{Key: "ns", Value: "zz.y"},
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.M{
+									"_id": int64(4),
+									"x":   json.NumberLong(-20),
+									"y":   json.NumberLong(5)}},
+							},
+							{
+								bson.E{Key: "ns", Value: "zz.y"},
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: int64(5)},
+									bson.E{Key: "x", Value: json.NumberLong(-30)},
+									bson.E{Key: "y", Value: json.NumberLong(11)},
+								}},
+							},
+						},
+					},
+				},
+				Timestamp:   utils.TimeToTimestamp(time.Now().Unix()),
+				Term:        &term[0],
+				Version:     2,
+				PrevOpTime:  utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				MultiOpType: &multiOpType[1], // 1 for vectored insert oplog format
+			},
+		}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 2, len(log.Object[0].Value.(bson.A)), "should be equal")
+		log1 := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				TxnNumber: &txnN[0],
+				Object: bson.D{
+					bson.E{
+						Key: "applyOps",
+						Value: []bson.D{
+							{
+								bson.E{Key: "ns", Value: "zl.y"},
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.M{
+									"_id": int64(4),
+									"x":   json.NumberLong(-20),
+									"y":   json.NumberLong(5)}},
+							},
+							{
+								bson.E{Key: "ns", Value: "zl.y"},
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: int64(5)},
+									bson.E{Key: "x", Value: json.NumberLong(-30)},
+									bson.E{Key: "y", Value: json.NumberLong(11)},
+								}},
+							},
+						},
+					},
+				},
+				Timestamp:   utils.TimeToTimestamp(time.Now().Unix()),
+				Term:        &term[0],
+				Version:     2,
+				PrevOpTime:  utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				MultiOpType: &multiOpType[1], // 1 for vectored insert oplog format
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log1), "should be equal")
 	}
 }
 

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -248,7 +248,7 @@ func TestNamespaceFilter(t *testing.T) {
 		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
 	}
 
-	// applyOps with delete op for config.system.sessions
+	// applyOps with inner delete ops for 'config.system.sessions'
 	// NamespaceFilter will not handle it, it's handled by AutologousFilter
 	{
 		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
@@ -392,6 +392,65 @@ func TestNamespaceFilter(t *testing.T) {
 		}
 		assert.Equal(t, true, filter.Filter(log1), "should be equal")
 	}
+
+	// applyOps with inner delete ops for 'config.system.preimages'
+	// NamespaceFilter will not handle it, it's handled by AutologousFilter
+	{
+		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
+		nr++
+		filter := NewNamespaceFilter(nil, nil)
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key: "applyOps",
+						Value: []bson.D{
+							{
+								bson.E{Key: "op", Value: "d"},
+								bson.E{Key: "ns", Value: "config.system.preimages"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: bson.D{
+										bson.E{Key: "nsUUID", Value: primitive.Binary{
+											Subtype: 4,
+											Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+										}},
+										bson.E{Key: "ts", Value: primitive.Timestamp{T: 1758155667, I: 24}},
+										bson.E{Key: "applyOpsIndex", Value: 0},
+									}},
+								}},
+							},
+							{
+								bson.E{Key: "op", Value: "d"},
+								bson.E{Key: "ns", Value: "config.system.preimages"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: bson.D{
+										bson.E{Key: "nsUUID", Value: primitive.Binary{
+											Subtype: 4,
+											Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+										}},
+										bson.E{Key: "ts", Value: primitive.Timestamp{T: 175855668, I: 2}},
+										bson.E{Key: "applyOpsIndex", Value: 0},
+									}},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 2, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
 }
 
 func TestGidFilter(t *testing.T) {
@@ -530,6 +589,27 @@ func TestAutologousFilter(t *testing.T) {
 		log = &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
 				Namespace: "a.system.profile",
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+
+		log = &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "config.system.preimages",
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+
+		log = &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "config.migrationCoordinators",
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+
+		log = &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "config.rangeDeletions",
 			},
 		}
 		assert.Equal(t, true, filter.Filter(log), "should be equal")

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -233,7 +233,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 		case "applyOps":
 			// parse and reorganize all inner ops within the transaction.
 			var ops []bson.D
-			var remainOps []interface{}
+			var remainOps bson.A
 			// it's very strange, some documents are []interface, some are []bson.D
 			switch v := oplog.GetKey(log.Object, "applyOps").(type) {
 			case []interface{}:

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -231,9 +231,15 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 			log.Namespace = ns
 			return filter.filter(log)
 		case "applyOps":
-			// parse and reorganize all inner ops within the transaction.
+			// parse and reorganize all inner ops within the transaction,
+			// also handle vectored insert oplog format with {multiOpType:1} introduced in 8.0
 			var ops []bson.D
 			var remainOps bson.A
+
+			isVectoredInsert := false
+			if log.MultiOpType != nil && *log.MultiOpType == 1 {
+				isVectoredInsert = true
+			}
 			// it's very strange, some documents are []interface, some are []bson.D
 			switch v := oplog.GetKey(log.Object, "applyOps").(type) {
 			case []interface{}:
@@ -253,6 +259,10 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 			for _, ele := range ops {
 				innerNs := oplog.GetKey(ele, "ns").(string)
 				if filter.FilterNs(innerNs) {
+					if isVectoredInsert {
+						LOG.Info("filter vectored insert ops with ns:%v in o.applyOps oplog", innerNs)
+						return true
+					}
 					LOG.Info("filter inner op with ns:%v in txn:%v", innerNs, log.Object)
 					continue
 				} else {

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -76,7 +76,7 @@ func (filter *AutologousFilter) Filter(log *oplog.PartialLog) bool {
 			_ = LOG.Warn("ExtractInnerNs meets error:%v", err)
 			return false
 		}
-		if ns == "config.system.sessions" {
+		if ns == "config.system.sessions" || ns == "config.system.preimages" {
 			return true
 		}
 	}

--- a/collector/syncer.go
+++ b/collector/syncer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alibaba/MongoShake/v2/collector/filter"
 	sourceReader "github.com/alibaba/MongoShake/v2/collector/reader"
 	utils "github.com/alibaba/MongoShake/v2/common"
+	journal "github.com/alibaba/MongoShake/v2/journal"
 	"github.com/alibaba/MongoShake/v2/oplog"
 	"github.com/alibaba/MongoShake/v2/quorum"
 	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
@@ -69,7 +70,7 @@ type OplogSyncer struct {
 	// source mongo oplog/event reader
 	reader sourceReader.Reader
 	// journal log that records all oplogs
-	journal *utils.Journal
+	journal *journal.Journal
 	// oplogs dispatcher
 	batcher *Batcher
 	// data persist handler
@@ -113,7 +114,7 @@ func NewOplogSyncer(
 		Replset:                replset,
 		startPosition:          startPosition,
 		fullSyncFinishPosition: utils.Int64ToTimestamp(fullSyncFinishPosition),
-		journal: utils.NewJournal(utils.JournalFileName(
+		journal: journal.NewJournal(journal.FileName(
 			fmt.Sprintf("%s.%s", conf.Options.Id, replset))),
 		reader: reader,
 		qos:    utils.StartQoS(0, 1, &utils.IncrSentinelOptions.TPS), // default is 0 which means do not limit

--- a/common/common.go
+++ b/common/common.go
@@ -156,7 +156,7 @@ func BlockMongoUrlPassword(url, replace string) string {
 		}
 	}
 
-	at := strings.Index(url, "@")
+	at := strings.LastIndex(url, "@")
 	if at == -1 || at == len(url)-1 || at <= colon {
 		return url
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -19,13 +19,8 @@ var SIGNALPROFILE = "$"
 var SIGNALSTACK = "$"
 
 const (
-	// APPNAME = "mongoshake"
-	// AppDatabase          = APPNAME
-	// APPConflictDatabase  = APPNAME + "_conflict"
-
 	GlobalDiagnosticPath = "diagnostic"
-	// This is the time of golang was born to the world
-	GolangSecurityTime = "2006-01-02T15:04:05Z"
+	GolangSecurityTime   = "2006-01-02T15:04:05Z"
 
 	WorkGood       uint64 = 0
 	GetReady       uint64 = 1

--- a/common/common.go
+++ b/common/common.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -137,12 +136,9 @@ func DelayFor(ms int64) {
 	YieldInMs(ms)
 }
 
-/**
- * block password in mongo_urls:
- * two kind mongo_urls:
- * 1. mongodb://username:password@address
- * 2. username:password@address
- */
+// BlockMongoUrlPassword block password in two kinds of mongo_urls:
+// 1) "mongodb://username:password@address"
+// 2) "username:password@address"
 func BlockMongoUrlPassword(url, replace string) string {
 	colon := strings.Index(url, ":")
 	if colon == -1 || colon == len(url)-1 {
@@ -176,21 +172,11 @@ func BlockMongoUrlPassword(url, replace string) string {
 	}
 	return string(newUrl)
 }
-
-// marshal given struct by json
-func MarshalStruct(input interface{}) string {
-	ret, err := json.Marshal(input)
-	if err != nil {
-		return fmt.Sprintf("marshal struct failed[%v]", err)
-	}
-	return string(ret)
-}
-
 func DuplicateKey(err error) bool {
 	return mongo.IsDuplicateKeyError(err)
 }
 
-// Return true only Indexe only have key _id
+// HaveIdIndexKey return true if index key is just '_id'
 func HaveIdIndexKey(obj bson.D) bool {
 	for _, ele := range obj {
 		if ele.Key != "key" {

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alibaba/MongoShake/v2/unit_test_common"
@@ -72,7 +72,7 @@ func TestMongoConn(t *testing.T) {
 		fmt.Printf("TestMongoConn case %d.\n", nr)
 		nr++
 
-		conn, err := NewMongoCommunityConn(testUrlSsl, VarMongoConnectModePrimary, true, "", "", "/u02/shuntong.zhang/db_mac_src/ApsaraDB-CA-Chain/ApsaraDB-CA-Chain.pem")
+		conn, err := NewMongoCommunityConn(testUrlSsl, VarMongoConnectModePrimary, true, "", "", "/Users/zhongli/workspace/ApsaraDB-CA-Chain.pem")
 		assert.Equal(t, err, nil, "should be equal")
 		assert.Equal(t, conn != nil, true, "should be equal")
 	}

--- a/common/community_client.go
+++ b/common/community_client.go
@@ -7,6 +7,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"net/url"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -76,7 +78,15 @@ func loadCert(data []byte) ([]byte, error) {
 func NewMongoCommunityConn(url string, connectMode string, timeout bool, readConcern,
 	writeConcern string, sslRootFile string) (*MongoCommunityConn, error) {
 
-	clientOps := options.Client().ApplyURI(url)
+	// URL encoding at first
+	encodedURL, err := EncodeMongoURI(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode MongoDB URL: %v", err)
+	}
+	LOG.Debug("encodedURL:[%v]", encodedURL)
+
+	clientOps := options.Client().ApplyURI(encodedURL)
+	//clientOps := options.Client().ApplyURI(url)
 
 	// tls tlsInsecure + tlsCaFile
 	if sslRootFile != "" {
@@ -262,4 +272,63 @@ func (conn *MongoCommunityConn) IsTimeSeriesCollection(dbName string, collName s
 	_, timeseries := res.Lookup("timeseries").DocumentOK()
 
 	return timeseries
+}
+
+// EncodeMongoURI encodes MongoDB URIs, mainly performing URL encoding on the password part.
+// expected to handle the following URI:
+// 1) normal one: "mongodb://user:password@localhost:27017/admin"
+// 2) with special chars: "mongodb://root:~!@#$^&*()_-=@localhost:27017/admin"
+// 3) without path: "mongodb://user:password@localhost:27017"
+// 4) auth disabled: "mongodb://localhost:27017"
+func EncodeMongoURI(uri string) (string, error) {
+	// split scheme and rest
+	parts := strings.SplitN(uri, ":", 2)
+	if len(parts) != 2 || !strings.HasPrefix(parts[1], "//") {
+		return "", fmt.Errorf("invalid URI scheme")
+	}
+	scheme := parts[0]
+	if scheme != "mongodb" {
+		return "", fmt.Errorf("unsupported scheme: %s", scheme)
+	}
+	rest := parts[1][2:] // remove "//"
+
+	// split user:pwd and hosts
+	atIndex := strings.LastIndex(rest, "@")
+	if atIndex == -1 { // coule be no-auth, do nothing
+		//return "", fmt.Errorf("missing '@' in URI")
+		return uri, nil
+	}
+	userInfoPart := rest[:atIndex]
+	afterUserInfo := rest[atIndex+1:]
+
+	// split user and password
+	userPassParts := strings.SplitN(userInfoPart, ":", 2)
+	if len(userPassParts) != 2 {
+		return "", fmt.Errorf("missing ':' in username:password")
+	}
+	username := userPassParts[0]
+	password := userPassParts[1]
+	if username == "" || password == "" {
+		return "", fmt.Errorf("missing username or password in username:password")
+	}
+
+	// split hosts and path
+	hostPathParts := strings.SplitN(afterUserInfo, "/", 2)
+	host := hostPathParts[0]
+	var path string
+	if len(hostPathParts) > 1 {
+		path = "/" + hostPathParts[1]
+	} else {
+		path = ""
+	}
+
+	// generate URL
+	u := &url.URL{
+		Scheme: scheme,
+		User:   url.UserPassword(username, password),
+		Host:   host,
+		Path:   path,
+	}
+
+	return u.String(), nil
 }

--- a/common/community_client.go
+++ b/common/community_client.go
@@ -147,8 +147,8 @@ func NewMongoCommunityConn(url string, connectMode string, timeout bool, readCon
 	// ping
 	if err = client.Ping(ctx, clientOps.ReadPreference); err != nil {
 		return nil, fmt.Errorf("ping to %v failed: %v\n"+
-			"If Mongo Server is standalone(single node) Or conn address is different with mongo server address"+
-			" try atandalone mode by mongodb://ip:port/admin?direct=ture",
+			"If mongo server is standalone(single node) or conn address is different with mongo server address"+
+			" try a standalone mode by mongodb://ip:port/admin?directConnection=true",
 			BlockMongoUrlPassword(url, "***"), err)
 	}
 

--- a/common/community_client_test.go
+++ b/common/community_client_test.go
@@ -130,3 +130,82 @@ func TestCommonFunctions(t *testing.T) {
 		conn.Close()
 	}
 }
+
+func TestEncodeMongoURI(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		err      string
+	}{
+		{
+			input:    "mongodb://root:password001@localhost:27017/admin",
+			expected: "mongodb://root:password001@localhost:27017/admin",
+			err:      "",
+		},
+		{
+			input:    "mongodb://root:1234@abcd@localhost:27017/admin",
+			expected: "mongodb://root:1234%40abcd@localhost:27017/admin",
+			err:      "",
+		},
+		{
+			input:    "mongodb://root:dUM3!k&TdofokP0yl1@dds-xxx1.mongodb.rds.aliyuncs.com:3717,dds-xxx2.mongodb.rds.aliyuncs.com:3717",
+			expected: "mongodb://root:dUM3%21k&TdofokP0yl1@dds-xxx1.mongodb.rds.aliyuncs.com:3717,dds-xxx2.mongodb.rds.aliyuncs.com:3717",
+			err:      "",
+		},
+		{
+			input:    "mongodb://root_special_char:MongoDB@%()!#&-=@localhost:27017/admin",
+			expected: "mongodb://root_special_char:MongoDB%40%25%28%29%21%23&-=@localhost:27017/admin",
+			err:      "",
+		},
+		{
+			input:    "mongodb://root_special_char1:~!@#$^&*()_-=@localhost:27017/admin",
+			expected: "mongodb://root_special_char1:~%21%40%23$%5E&%2A%28%29_-=@localhost:27017/admin",
+			err:      "",
+		},
+		{
+			input:    "mongodb://user:pass@localhost/db",
+			expected: "mongodb://user:pass@localhost/db",
+			err:      "",
+		},
+		{
+			input:    "mongodb://user:pass:@localhost/db",
+			expected: "mongodb://user:pass%3A@localhost/db",
+			err:      "",
+		},
+		{
+			input:    "mongodb://user:passwd@localhost:27017",
+			expected: "mongodb://user:passwd@localhost:27017",
+			err:      "",
+		},
+		{
+			input:    "mongodb://localhost:27017,localhost:27018",
+			expected: "mongodb://localhost:27017,localhost:27018",
+			err:      "",
+		},
+		{
+			input: "invalid://user:pass@host/db",
+			err:   "unsupported scheme: invalid",
+		},
+		{
+			input: "mongodb://user@host/db",
+			err:   "missing ':' in username:password",
+		},
+		{
+			input: "mongodb://:@host/db",
+			err:   "missing username or password in username:password",
+		},
+	}
+
+	for _, tt := range tests {
+		encoded, err := EncodeMongoURI(tt.input)
+		if tt.err != "" {
+			if err == nil || err.Error() != tt.err {
+				t.Errorf("expected error %q for %q, got %v", tt.err, tt.input, err)
+			}
+		} else {
+			if encoded != tt.expected {
+				t.Errorf("expected %q for %q, got %q", tt.expected, tt.input, encoded)
+			}
+		}
+	}
+}

--- a/common/db_opertion.go
+++ b/common/db_opertion.go
@@ -183,14 +183,18 @@ func GetAllTimestamp(sources []*MongoSource, sslRootFile string) (map[string]Tim
 	tsMap := make(map[string]TimestampNode)
 
 	for _, src := range sources {
-		newest, err := GetNewestTimestampByUrl(src.URL, false, sslRootFile)
+		fromMongos := false
+		if src.ReplicaName == ReplicaNameMongos {
+			fromMongos = true
+		}
+		newest, err := GetNewestTimestampByUrl(src.URL, fromMongos, sslRootFile)
 		if err != nil {
 			return nil, 0, 0, 0, 0, err
 		} else if newest == 0 {
 			return nil, 0, 0, 0, 0, fmt.Errorf("illegal newest timestamp == 0")
 		}
 
-		oldest, err := GetOldestTimestampByUrl(src.URL, false, sslRootFile)
+		oldest, err := GetOldestTimestampByUrl(src.URL, fromMongos, sslRootFile)
 		if err != nil {
 			return nil, 0, 0, 0, 0, err
 		}

--- a/common/define.go
+++ b/common/define.go
@@ -80,6 +80,9 @@ const (
 	MongoVersion32  = "3.2.0"
 	MongoVersion36  = "3.6.0"
 	MongoVersion401 = "4.0.1"
+
+	// replica name for ReplicationCoordinator
+	ReplicaNameMongos = "mongos"
 )
 
 type Pair struct {

--- a/common/define.go
+++ b/common/define.go
@@ -74,6 +74,12 @@ const (
 
 	// special
 	VarSpecialSourceDBFlagAliyunServerless = "aliyun_serverless"
+
+	// mongo dbVersions
+	MongoVersion26  = "2.6.0"
+	MongoVersion32  = "3.2.0"
+	MongoVersion36  = "3.6.0"
+	MongoVersion401 = "4.0.1"
 )
 
 type Pair struct {

--- a/common/fcv.go
+++ b/common/fcv.go
@@ -28,7 +28,7 @@ var (
 		9:  "2.4.21", // remove incr_sync.worker.oplog_compressor; add incr_sync.tunnel.write_thread, tunnel.kafka.partition_number
 		10: "2.6.4",  // remove full_sync.reader.read_document_count; add full_sync.reader.parallel_thread, incr_sync.reader.fetch_batch_size, skip.nsshardkey.verify
 		11: "2.8.6",  // add incr_sync.fetcher.buffer_size_threshold_in_kb, full_sync.do_not_shard_destination
-		12: "2.8.7",  // add incr_sync.executor.bypass_document_validation
+		12: "2.8.7",  // add incr_sync.executor.bypass_document_validation, tunnel.kafka.sasl.enable, tunnel.kafka.sasl.auth, tunnel.kafka.sasl.mechanism, tunnel.kafka.compression, tunnel.kafka.producer.max_message_bytes, full_sync.reader.split_max_chunk_size
 	}
 )
 

--- a/common/fcv.go
+++ b/common/fcv.go
@@ -6,7 +6,7 @@ var (
 		FeatureCompatibleVersion: 1,
 	}
 	FcvConfiguration = Configuration{
-		CurrentVersion:           10,
+		CurrentVersion:           12,
 		FeatureCompatibleVersion: 10,
 	}
 
@@ -26,7 +26,9 @@ var (
 		7:  "2.4.17", // add filter.oplog.gids
 		8:  "2.4.20", // add special.source.db.flag
 		9:  "2.4.21", // remove incr_sync.worker.oplog_compressor; add incr_sync.tunnel.write_thread, tunnel.kafka.partition_number
-		10: "2.6.4",  // remove full_sync.reader.read_document_count; add full_sync.reader.parallel_thread
+		10: "2.6.4",  // remove full_sync.reader.read_document_count; add full_sync.reader.parallel_thread, incr_sync.reader.fetch_batch_size, skip.nsshardkey.verify
+		11: "2.8.6",  // add incr_sync.fetcher.buffer_size_threshold_in_kb, full_sync.do_not_shard_destination
+		12: "2.8.7",  // add incr_sync.executor.bypass_document_validation
 	}
 )
 
@@ -34,7 +36,6 @@ type Fcv interface {
 	IsCompatible(int) bool
 }
 
-// for checkpoint
 type Checkpoint struct {
 	/*
 	 * version: 0(or set not), MongoShake < 2.4, fcv == 0
@@ -48,7 +49,6 @@ func (c Checkpoint) IsCompatible(v int) bool {
 	return v >= c.FeatureCompatibleVersion && v <= c.CurrentVersion
 }
 
-// for configuration
 type Configuration struct {
 	/*
 	 * version: 0(or set not), MongoShake < 2.4.0, fcv == 0

--- a/common/parse.go
+++ b/common/parse.go
@@ -37,3 +37,13 @@ func SetFiled(input bson.D, key string, value interface{}, upsert bool) {
 			Value: value})
 	}
 }
+
+func MarshalData(input bson.D) bson.Raw {
+	var dataRaw bson.Raw
+	if data, err := bson.Marshal(input); err != nil {
+		return nil
+	} else {
+		dataRaw = data[:]
+	}
+	return dataRaw
+}

--- a/common/sentinel.go
+++ b/common/sentinel.go
@@ -15,8 +15,8 @@ const (
 	TypeIncr = "incr"
 )
 
-// IncrSentinelOptions. option's value type should be
-// String or Bool or Int64
+// IncrSentinelOptions
+// option's value type should be String or Bool or Int64
 // only used in incremental sync.
 var IncrSentinelOptions struct {
 	OplogDump      int64
@@ -28,6 +28,7 @@ var IncrSentinelOptions struct {
 	Shutdown       bool  // close shake
 }
 
+// FullSentinelOptions
 // only used in full sync.
 var FullSentinelOptions struct {
 	TPS int64
@@ -78,7 +79,7 @@ func (sentinel *Sentinel) Register() {
 	})
 
 	provider.RegisterAPI("/sentinel/options", nimo.HttpPost, func(body []byte) interface{} {
-		// check the exist of every option. options will be configured only
+		// check the existence of every option. options will be configured only
 		// if all the header kv pair are exist! this means that we ensure the
 		// operation consistency
 

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -38,7 +38,7 @@ log.level = info
 # log directory. log and pid file will be stored into this file.
 # if not set, default is "./logs/"
 # log和pid文件的目录，如果不设置默认打到当前路径的logs目录。
-log.dir =
+log.dir = logs
 # log file name.
 # log文件名。
 log.file = collector.log

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -5,7 +5,7 @@
 
 # current configuration version, do not modify.
 # 当前配置文件的版本号，请不要修改该值。
-conf.version = 11
+conf.version = 12
 
 # --------------------------- global configuration ---------------------------
 # collector name
@@ -231,6 +231,7 @@ full_sync.executor.filter.orphan_document = false
 # 全量阶段写入端是否启用majority write
 full_sync.executor.majority_enable = false
 
+
 # do not make destination collection sharding if source collection is sharding
 # 不要在目标端执行shardCollection的操作，仅在从分片到副本集的同步场景才需要设置为true
 full_sync.do_not_shard_destination = false
@@ -319,6 +320,9 @@ incr_sync.conflict_write_to = none
 # the performance will degrade if enable.
 # 增量阶段写入端是否启用majority write
 incr_sync.executor.majority_enable = false
+# whether executor should bypass document validation or not.
+# 增量阶段写入是否临时绕开文档验证机制
+incr_sync.executor.bypass_document_validation = false
 
 # --- direct tunnel only end ---
 

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -5,7 +5,7 @@
 
 # current configuration version, do not modify.
 # 当前配置文件的版本号，请不要修改该值。
-conf.version = 13
+conf.version = 14
 
 # --------------------------- global configuration ---------------------------
 # collector name
@@ -226,6 +226,11 @@ full_sync.reader.parallel_thread = 1
 # 如果设置了full_sync.reader.parallel_thread，还需要设置该参数，并行拉取所扫描的index，value
 # 必须是同种类型。对于副本集，建议设置_id；对于集群版，建议设置shard_key。key只能有1个field。
 full_sync.reader.parallel_index = _id
+# maxChunkSize for splitVector, default is 1024MB, this value should be [1,1024]MB since below versions:
+# 4.2.24, 4.4.19, 5.0.13, 6.0.2, see more details in: https://github.com/alibaba/MongoShake/issues/923
+# 要使用单表并发拉取，splitVector命令的maxChunkSize从某些小版本开始就不能超过1024MB，否则会报错。(4.2.24, 4.4.19, 5.0.13, 6.0.2)
+# 详情可参考如下issue中的讨论：https://github.com/alibaba/MongoShake/issues/923
+full_sync.reader.split_max_chunk_size = 1024
 
 # drop the same name of collection in dest mongodb in full synchronization
 # 同步时如果目的库存在，是否先删除目的库再进行同步，true表示先删除再同步，false表示不删除。

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -58,8 +58,9 @@ sync_mode = incr
 # connect source mongodb, set username and password if enable authority. Please note: password shouldn't contain '@'.
 # split by comma(,) if use multiple instance in one replica-set. E.g., mongodb://username1:password1@primaryA,secondaryB,secondaryC
 # split by semicolon(;) if sharding enable. E.g., mongodb://username1:password1@primaryA,secondaryB,secondaryC;mongodb://username2:password2@primaryX,secondaryY,secondaryZ
-# 源MongoDB连接串信息，逗号分隔同一个副本集内的结点，分号分隔分片sharding实例，免密模式
-# 可以忽略“username:password@”，注意，密码里面不能含有'@'符号。
+# 源MongoDB连接串信息，逗号分隔同一个副本集内的结点，分号分隔分片sharding实例，免密模式可以忽略“username:password@”
+# 注意，密码里面如果含有'@'等特殊字符的话，shake会按照如下的URL编码方式进行处理。
+# https://help.aliyun.com/zh/mongodb/support/connection-access-and-network
 # 举例：
 # 副本集：mongodb://username1:password1@primaryA,secondaryB,secondaryC
 # 分片集：mongodb://username1:password1@primaryA,secondaryB,secondaryC;mongodb://username2:password2@primaryX,secondaryY,secondaryZ

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -5,7 +5,7 @@
 
 # current configuration version, do not modify.
 # 当前配置文件的版本号，请不要修改该值。
-conf.version = 12
+conf.version = 13
 
 # --------------------------- global configuration ---------------------------
 # collector name
@@ -102,6 +102,24 @@ tunnel.message = raw
 # how many partitions will be written, use some hash function in "incr_sync.shard_key".
 # 如果目的端是kafka，最多启用多少个partition，最大不超过"incr_sync.worker"。默认1
 tunnel.kafka.partition_number = 1
+# Whether or not to use SASL authentication when connecting to the broker
+# (defaults to false).
+tunnel.kafka.sasl.enable = false
+# for kafka. this is the username and password auth which split by comma, for instance: username@password
+# UserName is the authentication identity (authcid) to present for
+# SASL/PLAIN or SASL/SCRAM authentication
+# Password for SASL/PLAIN authentication
+tunnel.kafka.sasl.auth =
+# SASLMechanism is the name of the enabled SASL mechanism.
+# Currently only supported values: PLAIN、SCRAM-SHA-256和SCRAM-SHA-512 (defaults to PLAIN).
+tunnel.kafka.sasl.mechanism = PLAIN
+#represents the various compression codecs recognized by Kafka in messages.
+#supported values:none,gzip,snappy,lz4,zstd
+tunnel.kafka.compression = none
+#The maximum permitted size of a message (defaults to 18*1024*1024). Should be
+#set equal to or smaller than the broker's `message.max.bytes`.
+tunnel.kafka.producer.max_message_bytes = 18*1024*1024
+
 # tunnel json format, it'll only take effect in the case of tunnel.message = json
 # and tunnel == kafka. Set canonical_extended_json if you want to use "Canonical
 # Extended JSON Format", #559.

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -216,9 +216,11 @@ full_sync.collection_exist_drop = true
 # none: do not create indexes.
 # foreground: create indexes when data sync finish in full sync stage.
 # background: create indexes when starting.
-# 全量期间数据同步完毕后，是否需要创建索引，none表示不创建，foreground表示创建前台索引，
-# background表示创建后台索引。
-full_sync.create_index = none
+# 全量期间数据同步完毕后，是否需要创建索引。none表示不创建，foreground表示创建前台索引，background表示创建后台索引。
+# 从4.2开始就是强制后台建，background option已经失去了其原本的语义，会被忽略。而且4.4+开始用两阶段索引创建流程，所有承载数据的节点都会
+# 一起开始后台建。详情可参考：
+# https://www.mongodb.com/docs/manual/core/index-creation/#comparison-to-foreground-and-background-builds
+full_sync.create_index = background
 
 # convert insert to update when duplicate key found
 # 如果_id存在在目的库，是否将insert语句修改为update语句。

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -33,6 +33,9 @@ func (bw *BulkWriter) doInsert(database, collection string, metadata bson.E, opl
 	}
 
 	opts := options.BulkWrite().SetOrdered(false)
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		opts = opts.SetBypassDocumentValidation(true)
+	}
 	res, err := bw.conn.Client.Database(database).Collection(collection).BulkWrite(nil, models, opts)
 
 	if err != nil {
@@ -91,7 +94,11 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 		LOG.Debug("bulk_writer: updateOnInsert %v", log.original.partialLog)
 	}
 
-	res, err := bw.conn.Client.Database(database).Collection(collection).BulkWrite(nil, models, nil)
+	opts := options.BulkWrite()
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		opts = opts.SetBypassDocumentValidation(true)
+	}
+	res, err := bw.conn.Client.Database(database).Collection(collection).BulkWrite(nil, models, opts)
 
 	if err != nil {
 		// parse error
@@ -306,8 +313,12 @@ func (bw *BulkWriter) doUpdate(database, collection string, metadata bson.E, opl
 
 	LOG.Debug("bulk_writer: update models len %v", len(models))
 
+	opts := options.BulkWrite()
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		opts = opts.SetBypassDocumentValidation(true)
+	}
 	res, err := bw.conn.Client.Database(database).Collection(collection).BulkWrite(
-		context.Background(), models, nil)
+		context.Background(), models, opts)
 
 	if err != nil {
 		// parse error

--- a/executor/db_writer_command.go
+++ b/executor/db_writer_command.go
@@ -33,9 +33,13 @@ func (cw *CommandWriter) doInsert(database, collection string, metadata bson.E, 
 	var err error
 	insertCmd := bson.D{
 		{"insert", collection},
-		{"bypassDocumentValidation", false},
 		{"documents", inserts},
 		{"ordered", ExecuteOrdered},
+	}
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		insertCmd = append(insertCmd, bson.E{Key: "bypassDocumentValidation", Value: true})
+	} else {
+		insertCmd = append(insertCmd, bson.E{Key: "bypassDocumentValidation", Value: false})
 	}
 	if metadata.Key == "g" {
 		insertCmd = append(insertCmd, metadata)
@@ -86,9 +90,13 @@ func (cw *CommandWriter) doUpdateOnInsert(database, collection string, metadata 
 	var err error
 	updateCmd := bson.D{
 		{"update", collection},
-		{"bypassDocumentValidation", false},
 		{"updates", updates},
 		{"ordered", ExecuteOrdered},
+	}
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		updateCmd = append(updateCmd, bson.E{Key: "bypassDocumentValidation", Value: true})
+	} else {
+		updateCmd = append(updateCmd, bson.E{Key: "bypassDocumentValidation", Value: false})
 	}
 	if metadata.Key == "g" {
 		updateCmd = append(updateCmd, metadata)
@@ -142,9 +150,13 @@ func (cw *CommandWriter) doUpdate(database, collection string, metadata bson.E, 
 	var err error
 	updateCmd := bson.D{
 		{"update", collection},
-		{"bypassDocumentValidation", false},
 		{"updates", updates},
 		{"ordered", ExecuteOrdered},
+	}
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		updateCmd = append(updateCmd, bson.E{Key: "bypassDocumentValidation", Value: true})
+	} else {
+		updateCmd = append(updateCmd, bson.E{Key: "bypassDocumentValidation", Value: false})
 	}
 	if metadata.Key == "g" {
 		updateCmd = append(updateCmd, metadata)

--- a/executor/db_writer_single.go
+++ b/executor/db_writer_single.go
@@ -48,7 +48,11 @@ func (sw *SingleWriter) doInsert(database, collection string, metadata bson.E, o
 	var upserts []*OplogRecord
 
 	for _, log := range oplogs {
-		if _, err := collectionHandle.InsertOne(context.Background(), log.original.partialLog.Object); err != nil {
+		opts := options.InsertOne()
+		if conf.Options.IncrSyncBypassDocumentValidation {
+			opts = opts.SetBypassDocumentValidation(true)
+		}
+		if _, err := collectionHandle.InsertOne(context.Background(), log.original.partialLog.Object, opts); err != nil {
 
 			if utils.DuplicateKey(err) {
 				upserts = append(upserts, log)
@@ -106,6 +110,9 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 		for _, update := range updates {
 
 			opts := options.Update().SetUpsert(true)
+			if conf.Options.IncrSyncBypassDocumentValidation {
+				opts = opts.SetBypassDocumentValidation(true)
+			}
 			res, err := collectionHandle.UpdateOne(context.Background(), update.id,
 				bson.D{{"$set", update.data}}, opts)
 			if err != nil {
@@ -130,9 +137,12 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 		}
 	} else {
 		for i, update := range updates {
-
+			opts := options.Update().SetUpsert(false)
+			if conf.Options.IncrSyncBypassDocumentValidation {
+				opts = opts.SetBypassDocumentValidation(true)
+			}
 			res, err := collectionHandle.UpdateOne(context.Background(), update.id,
-				bson.D{{"$set", update.data}}, nil)
+				bson.D{{"$set", update.data}}, opts)
 			if err != nil && utils.DuplicateKey(err) == false {
 				_ = LOG.Warn("update _id[%v] with data[%v] meets err[%v] res[%v], try to solve",
 					update.id, update.data, err, res)
@@ -235,6 +245,9 @@ func (sw *SingleWriter) doUpdate(database, collection string, metadata bson.E, o
 			if upsert {
 				opts.SetUpsert(true)
 			}
+			if conf.Options.IncrSyncBypassDocumentValidation {
+				opts = opts.SetBypassDocumentValidation(true)
+			}
 			if upsert && len(log.original.partialLog.DocumentKey) > 0 {
 				res, err = collectionHandle.UpdateOne(context.Background(), log.original.partialLog.DocumentKey,
 					update, opts)
@@ -252,6 +265,9 @@ func (sw *SingleWriter) doUpdate(database, collection string, metadata bson.E, o
 			opts := options.Replace()
 			if upsert {
 				opts.SetUpsert(true)
+			}
+			if conf.Options.IncrSyncBypassDocumentValidation {
+				opts = opts.SetBypassDocumentValidation(true)
 			}
 			if upsert && len(log.original.partialLog.DocumentKey) > 0 {
 				res, err = collectionHandle.ReplaceOne(context.Background(), log.original.partialLog.DocumentKey,

--- a/executor/db_writer_test.go
+++ b/executor/db_writer_test.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/mongodb/mongo-tools-common/json"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -1487,6 +1489,9 @@ func TestRunCommand(t *testing.T) {
 	// test RunCommand
 
 	_ = utils.InitialLogger("", "", "debug", true, 1)
+	txnN := []int64{0, 1}
+	term := []int64{1}
+	multiOpType := []int{0, 1}
 
 	var nr int
 
@@ -1508,7 +1513,7 @@ func TestRunCommand(t *testing.T) {
 
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
-				Operation: "i",
+				Operation: "c",
 				Namespace: "admin.$cmd",
 				Object: bson.D{
 					bson.E{
@@ -1554,6 +1559,74 @@ func TestRunCommand(t *testing.T) {
 		assert.Equal(t, "world", result[0]["hello"].(string), "should be equal")
 		assert.Equal(t, "789", result[1]["_id"].(string), "should be equal")
 		assert.Equal(t, "w2", result[1]["hello"].(string), "should be equal")
+		assert.Equal(t, int32(1), result[2]["x"], "should be equal")
+	}
+
+	// applyOps with {multiOpType:1} which should not be treated as txn.
+	{
+		fmt.Printf("TestRunCommand case %d.\n", nr)
+		nr++
+		conn, err := utils.NewMongoCommunityConn(testMongoAddress, "primary", true,
+			utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, "")
+		assert.Equal(t, nil, err, "should be equal")
+		// drop database
+		err = conn.Client.Database("zz").Drop(nil)
+		assert.Equal(t, nil, err, "should be equal")
+		_, err = conn.Client.Database("zz").Collection("y").InsertOne(context.Background(), bson.M{"x": 1})
+		assert.Equal(t, nil, err, "should be equal")
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				TxnNumber: &txnN[0],
+				Object: bson.D{
+					bson.E{
+						Key: "applyOps",
+						Value: []bson.M{
+							{
+								"ns": "zz.y",
+								"op": "i",
+								"ui": primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								},
+								"o": bson.M{"_id": int64(4), "x": json.NumberLong(-20), "y": json.NumberLong(5)},
+							},
+							{
+								"ns": "zz.y",
+								"op": "i",
+								"ui": primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								},
+								"o": bson.D{
+									bson.E{Key: "_id", Value: int64(5)},
+									bson.E{Key: "x", Value: json.NumberLong(-30)},
+									bson.E{Key: "y", Value: json.NumberLong(11)},
+								},
+							},
+						},
+					},
+				},
+				Timestamp:   utils.TimeToTimestamp(time.Now().Unix()),
+				Term:        &term[0],
+				Version:     2,
+				PrevOpTime:  utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				MultiOpType: &multiOpType[1], // 1 for vectored insert oplog format
+			},
+		}
+		err = RunCommand(testDb, "applyOps", log, conn.Client)
+		assert.Equal(t, nil, err, "should be equal")
+		opts := options.Find().SetSort(bson.D{{"_id", 1}})
+		result, err := unit_test_common.FetchAllDocumentBsonM(conn.Client, "zz", "y", opts)
+		assert.Equal(t, nil, err, "should be equal")
+		fmt.Printf("result:%v\n", result)
+		assert.Equal(t, int64(4), result[0]["_id"].(int64), "should be equal")
+		assert.Equal(t, int64(-20), result[0]["x"].(int64), "should be equal")
+		assert.Equal(t, int64(5), result[0]["y"].(int64), "should be equal")
+		assert.Equal(t, int64(5), result[1]["_id"].(int64), "should be equal")
+		assert.Equal(t, int64(-30), result[1]["x"].(int64), "should be equal")
+		assert.Equal(t, int64(11), result[1]["y"].(int64), "should be equal")
 		assert.Equal(t, int32(1), result[2]["x"], "should be equal")
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -14,6 +14,7 @@ import (
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/transform"
 	utils "github.com/alibaba/MongoShake/v2/common"
+	"github.com/alibaba/MongoShake/v2/journal"
 	"github.com/alibaba/MongoShake/v2/oplog"
 	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
 )
@@ -169,7 +170,7 @@ type Executor struct {
 	// batchExecutor, not owned
 	batchExecutor *BatchGroupExecutor
 	// records all oplogRecords into journal files
-	journal *utils.Journal
+	journal *journal.Journal
 	// mongo url
 	MongoUrl string
 
@@ -207,7 +208,7 @@ func NewExecutor(id int, batchExecutor *BatchGroupExecutor, MongoUrl string) *Ex
 	return &Executor{
 		id:            id,
 		batchExecutor: batchExecutor,
-		journal:       utils.NewJournal(utils.JournalFileName(fmt.Sprintf("direct.%03d", id))),
+		journal:       journal.NewJournal(journal.FileName(fmt.Sprintf("direct.%03d", id))),
 		MongoUrl:      MongoUrl,
 		batchBlock:    make(chan []*OplogRecord, 1),
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -32,8 +32,7 @@ const (
 )
 
 var (
-	GlobalExecutorId int32  = -1
-	ThresholdVersion string = "3.2.0"
+	GlobalExecutorId int32 = -1
 )
 
 type PartialLogWithCallback struct {

--- a/executor/operation.go
+++ b/executor/operation.go
@@ -36,7 +36,7 @@ func (exec *Executor) ensureConnection() bool {
 			return false
 		} else {
 			exec.conn = conn
-			if exec.bulkInsert, err = utils.GetAndCompareVersion(exec.conn, ThresholdVersion,
+			if exec.bulkInsert, err = utils.GetAndCompareVersion(exec.conn, utils.MongoVersion32,
 				conf.Options.TargetDBVersion); err != nil {
 				LOG.Info("compare version with return[%v], bulkInsert disable", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/alibaba/MongoShake/v2
 
-go 1.15
+go 1.21
+
+toolchain go1.24.5
 
 require (
 	github.com/Shopify/sarama v1.27.2
@@ -9,9 +11,195 @@ require (
 	github.com/mongodb/mongo-tools-common v4.0.18+incompatible
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
-	github.com/smartystreets/goconvey v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/vinllen/go-diskqueue v1.0.2-0.20210318091137-9e570abf8db4
-	github.com/vinllen/log4go v0.0.0-20180514124125-3848a366df9d // indirect
 	go.mongodb.org/mongo-driver v1.9.0
+)
+
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	cloud.google.com/go/bigquery v1.8.0 // indirect
+	cloud.google.com/go/datastore v1.1.0 // indirect
+	cloud.google.com/go/firestore v1.1.0 // indirect
+	cloud.google.com/go/pubsub v1.3.1 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
+	dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/Shopify/toxiproxy v2.1.4+incompatible // indirect
+	github.com/antihax/optional v1.0.0 // indirect
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e // indirect
+	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
+	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/bketelsen/crypt v0.0.4 // indirect
+	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/client9/misspell v0.3.4 // indirect
+	github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/creack/pty v1.1.9 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/eapache/go-resiliency v1.2.0 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/fortytw2/leaktest v1.3.0 // indirect
+	github.com/frankban/quicktest v1.10.2 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 // indirect
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/godbus/dbus/v5 v5.0.4 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/mock v1.5.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
+	github.com/google/martian v2.1.0+incompatible // indirect
+	github.com/google/martian/v3 v3.1.0 // indirect
+	github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5 // indirect
+	github.com/google/renameio v0.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/consul/api v1.1.0 // indirect
+	github.com/hashicorp/consul/sdk v0.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-msgpack v0.5.3 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.0 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.0 // indirect
+	github.com/hashicorp/go-syslog v1.0.0 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go.net v0.0.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/mdns v1.0.0 // indirect
+	github.com/hashicorp/memberlist v0.1.3 // indirect
+	github.com/hashicorp/serf v0.8.2 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jcmturner/gofork v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/kisielk/errcheck v1.5.0 // indirect
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/kr/fs v0.1.0 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/pty v1.1.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.3 // indirect
+	github.com/miekg/dns v1.0.14 // indirect
+	github.com/mitchellh/cli v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.0.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/gox v0.4.0 // indirect
+	github.com/mitchellh/iochan v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86 // indirect
+	github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/sftp v1.10.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/posener/complete v1.1.1 // indirect
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
+	github.com/rogpeppe/fastuuid v1.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.3.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636 // indirect
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/smarty/assertions v1.15.0 // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
+	github.com/smartystreets/goconvey v1.8.1 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/cobra v1.2.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.8.1 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tidwall/pretty v1.0.0 // indirect
+	github.com/vinllen/log4go v0.0.0-20180514124125-3848a366df9d // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	github.com/yuin/goldmark v1.4.13 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0 // indirect
+	go.etcd.io/etcd/client/v2 v2.305.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
+	golang.org/x/image v0.0.0-20190802002840-cff245a6509b // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 // indirect
+	golang.org/x/mod v0.9.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/term v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.44.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
+	gopkg.in/errgo.v2 v2.1.0 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
+	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
+	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
+	gopkg.in/jcmturner/gokrb5.v7 v7.5.0 // indirect
+	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
+	rsc.io/binaryregexp v0.2.0 // indirect
+	rsc.io/quote/v3 v3.1.0 // indirect
+	rsc.io/sampler v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Shopify/sarama v1.27.2 h1:1EyY1dsxNDUQEv0O/4TsjosHI2CgB1uo9H/v56xzTxc=
 github.com/Shopify/sarama v1.27.2/go.mod h1:g5s5osgELxgM+Md9Qni9rzo7Rbt+vvFQI4bt/Mc93II=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=

--- a/journal/journal.go
+++ b/journal/journal.go
@@ -1,4 +1,4 @@
-package utils
+package journal
 
 import (
 	"bufio"
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/alibaba/MongoShake/v2/common"
 	"github.com/alibaba/MongoShake/v2/oplog"
 )
 
@@ -14,28 +15,28 @@ const (
 )
 
 const (
-	JournalNothingOnDefault = iota
-	JournalSampling
-	JournalAll
+	NothingOnDefault = iota
+	Sampling
+	All
 )
 
 const (
 	BufferCapacity = 4 * 1024 * 1024
 )
 
-var JournalFilePattern = GlobalDiagnosticPath + string(filepath.Separator) + "%s.journal"
+var FilePattern = utils.GlobalDiagnosticPath + string(filepath.Separator) + "%s.journal"
 
 type Journal struct {
 	writer *bufio.Writer
 	hasher oplog.Hasher
 }
 
-func JournalFileName(identifier string) string {
-	return fmt.Sprintf(JournalFilePattern, identifier)
+func FileName(identifier string) string {
+	return fmt.Sprintf(FilePattern, identifier)
 }
 
 func NewJournal(name string) *Journal {
-	// dump every oplog detail if need
+	// dump every oplog detail if needed
 	if file, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND,
 		0666); err == nil {
 		w := bufio.NewWriterSize(file, BufferCapacity)
@@ -48,15 +49,15 @@ func (j *Journal) WriteRecord(oplog *oplog.PartialLog) {
 	// 0 -> no journal
 	// 1 -> sampling
 	// 2 -> journal all
-	switch IncrSentinelOptions.OplogDump {
-	case JournalNothingOnDefault: // default. do nothing
-	case JournalSampling:
+	switch utils.IncrSentinelOptions.OplogDump {
+	case NothingOnDefault: // default. do nothing
+	case Sampling:
 		// object id will be sampled and all DDL oplog
 		if j.hasher.DistributeOplogByMod(oplog, SampleFrequency) != 0 {
 			break
 		}
 		fallthrough
-	case JournalAll:
+	case All:
 		j.journal(oplog)
 	default:
 	}

--- a/oplog/change_stream_event.go
+++ b/oplog/change_stream_event.go
@@ -240,7 +240,7 @@ func ConvertEvent2Oplog(input []byte, fullDoc bool) (*PartialLog, error) {
 		oplog.Namespace = fmt.Sprintf("%s.%s", ns["db"], ns["coll"])
 		oplog.Operation = "u"
 		oplog.Query = event.DocumentKey
-		oplog.Object = event.FullDocument
+		oplog.Object = bson.D{bson.E{Key: "$set", Value: event.FullDocument}}
 	case "update":
 		/*
 		 * PRIMARY> db.test.find()

--- a/oplog/change_stream_event_test.go
+++ b/oplog/change_stream_event_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
+	utils "github.com/alibaba/MongoShake/v2/common"
 	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
 	"github.com/alibaba/MongoShake/v2/unit_test_common"
 )
@@ -75,8 +76,13 @@ func marshalData(input bson.M) bson.Raw {
 	return dataRaw
 }
 
+// newMongoClient only used in unit test
 func newMongoClient(url string) (*mongo.Client, error) {
-	clientOps := options.Client().ApplyURI(url)
+	encodedURL, err := utils.EncodeMongoURI(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode MongoDB URL: %v", err)
+	}
+	clientOps := options.Client().ApplyURI(encodedURL)
 
 	client, err := mongo.NewClient(clientOps)
 	if err != nil {

--- a/oplog/hasher.go
+++ b/oplog/hasher.go
@@ -14,7 +14,7 @@ const (
 )
 
 const (
-	DefaultHashValue = 0
+	DefaultHashValue = uint32(0)
 )
 
 type Hasher interface {
@@ -42,13 +42,14 @@ func (collectionHasher *TableHasher) DistributeOplogByMod(log *PartialLog, mod i
 	return stringHashValue(log.Namespace) % uint32(mod)
 }
 
-// PrimaryKeyHasher hash by objectID
+// PrimaryKeyHasher will try to hash by _id firstly, {op:c} will use namespace instead
 type PrimaryKeyHasher struct {
 	Hasher
 }
 
 // DistributeOplogByMod
 // We need to ensure that oplog entry will be sent to the same job[$hash] if they have the same ObjectID.
+// thus we can consume the oplog entry sequentially
 func (objectIdHasher *PrimaryKeyHasher) DistributeOplogByMod(log *PartialLog, mod int) uint32 {
 	if mod == 1 {
 		return 0
@@ -129,6 +130,11 @@ func GetIdOrNSFromOplog(log *PartialLog) interface{} {
 			return GetKey(log.Object, "")
 		}
 	case "c":
+		// we don't treat vectored insert oplog(o.applyOps:{$exists:true}) as txns and dispatch to fixed worker 0
+		if log.MultiOpType != nil && *log.MultiOpType == 1 {
+			// use 'ts' field to hash
+			return log.Timestamp.T + log.Timestamp.I
+		}
 		return log.Namespace
 	default:
 		_ = LOG.Critical("Unrecognized oplog object operation %s", log.Operation)
@@ -162,6 +168,12 @@ func Hash(hashObject interface{}) uint32 {
 		return uint32(object)
 	case int:
 		return uint32(object)
+	case uint:
+		return uint32(object)
+	case uint64:
+		return uint32(object)
+	case uint32:
+		return object
 	case nil:
 		_ = LOG.Warn("Hash object is NIL. use default value %d", DefaultHashValue)
 	default:

--- a/oplog/hasher_test.go
+++ b/oplog/hasher_test.go
@@ -2,22 +2,163 @@ package oplog
 
 import (
 	"fmt"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func TestHash(t *testing.T) {
+	var nr int
+
+	// primitive.ObjectID
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		objectID := primitive.NewObjectID()
+		hashVal := Hash(objectID)
+
+		assert.NotEqual(t, DefaultHashValue, hashVal, "Hash value for ObjectID should not be default")
+	}
+
+	// string
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		str := "test string"
+		hashVal := Hash(str)
+
+		assert.NotEqual(t, DefaultHashValue, hashVal, "Hash value for string should not be default")
+	}
+
+	// int64
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		var i64 int64 = 1234567890123456789
+		hashVal := Hash(i64)
+
+		assert.Equal(t, uint32(i64), hashVal, "Hash value for int64 should be truncated correctly")
+	}
+
+	// int32
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		var i32 int32 = 1234567890
+		hashVal := Hash(i32)
+
+		assert.Equal(t, uint32(i32), hashVal, "Hash value for int32 should be converted correctly")
+	}
+
+	// int
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		i := 1234567890
+		hashVal := Hash(i)
+
+		assert.Equal(t, uint32(i), hashVal, "Hash value for int should be converted correctly")
+	}
+
+	// uint
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		var ui uint = 1234567890
+		hashVal := Hash(ui)
+
+		assert.Equal(t, uint32(ui), hashVal, "Hash value for uint should be converted correctly")
+	}
+
+	// uint64
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		var ui64 uint64 = 1234567890123456789
+		hashVal := Hash(ui64)
+
+		assert.Equal(t, uint32(ui64), hashVal, "Hash value for uint64 should be truncated correctly")
+	}
+
+	// uint32
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		var ui32 uint32 = 1234567890
+		hashVal := Hash(ui32)
+
+		assert.Equal(t, ui32, hashVal, "Hash value for uint32 should be returned as is")
+	}
+
+	// nil
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		hashVal := Hash(nil)
+
+		assert.Equal(t, DefaultHashValue, hashVal, "Hash value for nil should be default")
+	}
+
+	// types which do not support like float64
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		f := 3.14159
+		hashVal := Hash(f)
+
+		assert.Equal(t, DefaultHashValue, hashVal, "Hash value for unsupported type should be default")
+	}
+
+	// diff ObjectID
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		objectID1 := primitive.NewObjectID()
+		objectID2, _ := primitive.ObjectIDFromHex("5e4fa224a6717632d6ee2e85")
+
+		hashVal1 := Hash(objectID1)
+		hashVal2 := Hash(objectID2)
+
+		assert.NotEqual(t, hashVal1, hashVal2, "Different ObjectIDs should produce different hash values")
+	}
+
+	// same string
+	{
+		t.Logf("TestHash case %d.\n", nr)
+		nr++
+
+		str1 := "same string"
+		str2 := "same string"
+
+		hashVal1 := Hash(str1)
+		hashVal2 := Hash(str2)
+
+		assert.Equal(t, hashVal1, hashVal2, "Same strings should produce same hash values")
+	}
+}
 func TestDistributeOplogByMod(t *testing.T) {
 	// test DistributeOplogByMod
 
 	var nr int
+	oid, _ := primitive.ObjectIDFromHex("5e4fa224a6717632d6ee2e85")
 
 	// TableHasher
 	// only for print
 	{
-		fmt.Printf("TestDistributeOplogByMod case %d.\n", nr)
+		fmt.Printf("TestDistributeOplogByMod case %d for TableHasher.\n", nr)
 		nr++
 
 		th := new(TableHasher)
@@ -42,17 +183,16 @@ func TestDistributeOplogByMod(t *testing.T) {
 
 	// PrimaryKeyHasher
 	{
-		fmt.Printf("TestDistributeOplogByMod case %d.\n", nr)
+		fmt.Printf("TestDistributeOplogByMod case %d for PrimaryKeyHasher.\n", nr)
 		nr++
 
 		pkh := new(PrimaryKeyHasher)
+		multiOpType := []int{0, 1}
 
 		log1 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", 123},
-				},
+				Query:     bson.D{{"_id", 123}},
 				Operation: "u",
 			},
 		}
@@ -60,21 +200,18 @@ func TestDistributeOplogByMod(t *testing.T) {
 		log2 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", 1230},
-				},
+				Query:     bson.D{{"_id", 1230}},
 				Operation: "u",
 			},
 		}
 
-		assert.NotEqual(t, pkh.DistributeOplogByMod(log2, 10000), pkh.DistributeOplogByMod(log1, 10000), "should be equal")
+		assert.NotEqual(t, pkh.DistributeOplogByMod(log2, 10000), pkh.DistributeOplogByMod(log1, 10000), "shouldn't be equal")
 
 		log3 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", int32(123)},
-				},
+				Query:     bson.D{{"_id", oid}},
+				Object:    bson.D{{"_id", oid}, {"x", 1}},
 				Operation: "u",
 			},
 		}
@@ -82,86 +219,97 @@ func TestDistributeOplogByMod(t *testing.T) {
 		log4 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", int32(1230)},
-				},
-				Operation: "u",
+				Object:    bson.D{{"_id", oid}},
+				Operation: "d",
 			},
 		}
 
-		assert.NotEqual(t, pkh.DistributeOplogByMod(log3, 10000), pkh.DistributeOplogByMod(log4, 10000), "should be equal")
+		assert.Equal(t, pkh.DistributeOplogByMod(log3, 8), pkh.DistributeOplogByMod(log4, 8), "should be equal")
 
+		// DDL
 		log5 := &PartialLog{
 			ParsedLog: ParsedLog{
-				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", "123"},
+				Namespace: "test.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{"createIndexes", "y"},
+					{"unique", true},
+					{"v", 2},
+					{"name", "x_1"},
+					{"key", bson.M{"x": 1}},
 				},
-				Operation: "u",
 			},
 		}
+		assert.Equal(t, Hash("test.$cmd")%8, pkh.DistributeOplogByMod(log5, 8), "should be equal")
 
+		// txn
 		log6 := &PartialLog{
 			ParsedLog: ParsedLog{
-				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", "1230"},
+				Timestamp: primitive.Timestamp{T: 1234, I: 1},
+				LSID:      bson.Raw{0, 0, 0, 0, 1},
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					{"applyOps", bson.A{
+						bson.D{{"op", "n"}},
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", oid}}}},
+						bson.D{{"op", "d"}, {"o", bson.D{{"x", 1}}}},
+					}},
+					{"partialTxn", true},
 				},
-				Operation: "u",
 			},
 		}
 
-		assert.NotEqual(t, pkh.DistributeOplogByMod(log5, 10000), pkh.DistributeOplogByMod(log6, 10000), "should be equal")
+		assert.Equal(t, Hash("admin.$cmd")%8, pkh.DistributeOplogByMod(log6, 8), "should be equal")
 
+		// vectored insert
+		prevOpTime, _ := bson.Marshal(bson.D{{"ts", primitive.Timestamp{T: 1234, I: 1}}})
 		log7 := &PartialLog{
 			ParsedLog: ParsedLog{
-				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", int64(123456789012345678)},
+				Timestamp: primitive.Timestamp{T: 1234, I: 1},
+				LSID:      bson.Raw{0, 0, 0, 0, 1},
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					{"applyOps", bson.A{
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", "1234"}}}, {"stmtId", 1}},
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", "1235"}}}, {"stmtId", 2}},
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", "1236"}}}, {"stmtId", 3}},
+					}},
 				},
-				Operation: "u",
+				Version:     2,
+				PrevOpTime:  []byte(emptyPrev),
+				MultiOpType: &multiOpType[1],
 			},
 		}
 
 		log8 := &PartialLog{
 			ParsedLog: ParsedLog{
-				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", int64(987654321098765432)},
+				Timestamp: primitive.Timestamp{T: 1234, I: 2},
+				LSID:      bson.Raw{0, 0, 0, 0, 1},
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					{"applyOps", bson.A{
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", "1237"}}}, {"stmtId", 4}},
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", "1238"}}}, {"stmtId", 5}},
+						bson.D{{"op", "i"}, {"o", bson.D{{"_id", "1239"}}}, {"stmtId", 6}},
+					}},
 				},
-				Operation: "u",
+				Version:     2,
+				PrevOpTime:  prevOpTime,
+				MultiOpType: &multiOpType[1],
 			},
 		}
 
-		assert.NotEqual(t, pkh.DistributeOplogByMod(log7, 10000), pkh.DistributeOplogByMod(log8, 10000), "should be equal")
-
-		oid1, _ := primitive.ObjectIDFromHex("684cde2b4aa2121c8b5907da")
-		log9 := &PartialLog{
-			ParsedLog: ParsedLog{
-				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", oid1},
-				},
-				Operation: "u",
-			},
-		}
-		oid2, _ := primitive.ObjectIDFromHex("684cde2b4aa2121c8b5907db")
-		log10 := &PartialLog{
-			ParsedLog: ParsedLog{
-				Namespace: "test.h4",
-				Query: bson.D{
-					{"_id", oid2},
-				},
-				Operation: "u",
-			},
-		}
-
-		assert.NotEqual(t, pkh.DistributeOplogByMod(log9, 10000), pkh.DistributeOplogByMod(log10, 10000), "should be equal")
+		assert.Equal(t, Hash(1234+1)%8, pkh.DistributeOplogByMod(log7, 8), "should be equal")
+		assert.Equal(t, Hash(1234+2)%8, pkh.DistributeOplogByMod(log8, 8), "should be equal")
+		assert.NotEqual(t, pkh.DistributeOplogByMod(log7, 8), pkh.DistributeOplogByMod(log8, 8), "shouldn't be equal")
 	}
 
 	// WhiteListObjectIdHasher
 	{
-		fmt.Printf("TestDistributeOplogByMod case %d.\n", nr)
+		fmt.Printf("TestDistributeOplogByMod case %d for WhiteListObjectIdHasher.\n", nr)
 		nr++
 
 		wloi := NewWhiteListObjectIdHasher([]string{"white1", "white5"})
@@ -190,9 +338,7 @@ func TestDistributeOplogByMod(t *testing.T) {
 		log3 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "white1",
-				Query: bson.D{
-					{"_id", 123},
-				},
+				Query:     bson.D{{"_id", 123}},
 				Operation: "u",
 			},
 		}
@@ -200,9 +346,7 @@ func TestDistributeOplogByMod(t *testing.T) {
 		log4 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "white1",
-				Query: bson.D{
-					{"_id", 1230},
-				},
+				Query:     bson.D{{"_id", 1230}},
 				Operation: "u",
 			},
 		}
@@ -212,9 +356,7 @@ func TestDistributeOplogByMod(t *testing.T) {
 		log5 := &PartialLog{
 			ParsedLog: ParsedLog{
 				Namespace: "white5",
-				Query: bson.D{
-					{"_id", 1230},
-				},
+				Query:     bson.D{{"_id", 1230}},
 				Operation: "u",
 			},
 		}

--- a/oplog/oplog.go
+++ b/oplog/oplog.go
@@ -6,10 +6,11 @@ import (
 	"reflect"
 	"strings"
 
-	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+
+	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
 )
 
 const (

--- a/oplog/oplog.go
+++ b/oplog/oplog.go
@@ -37,9 +37,10 @@ type ParsedLog struct {
 	FromMigrate   bool                `bson:"fromMigrate,omitempty" json:"fromMigrate,omitempty"` // move chunk
 	TxnNumber     *int64              `bson:"txnNumber,omitempty" json:"txnNumber,omitempty"`     // transaction number in session
 	DocumentKey   bson.D              `bson:"documentKey,omitempty" json:"documentKey,omitempty"` // exists when source collection is sharded, only including shard key and _id
-	PrevOpTime    bson.Raw            `bson:"prevOpTime,omitempty"`
-	UI            *primitive.Binary   `bson:"ui,omitempty" json:"ui,omitempty"` // do not enable currently
-	Upsert        bool                `bson:"b,omitempty" json:"b,omitempty"`   // upsert for update op
+	PrevOpTime    bson.Raw            `bson:"prevOpTime,omitempty" json:"prevOpTime,omitempty"`
+	UI            *primitive.Binary   `bson:"ui,omitempty" json:"ui,omitempty"`                   // do not enable currently
+	Upsert        bool                `bson:"b,omitempty" json:"b,omitempty"`                     // upsert for update op
+	MultiOpType   *int                `bson:"multiOpType,omitempty" json:"multiOpType,omitempty"` // added in 8.0 for vectored insert
 }
 
 type PartialLog struct {

--- a/oplog/testdata/oplog_entries.json
+++ b/oplog/testdata/oplog_entries.json
@@ -1,0 +1,411 @@
+{
+  "not transaction": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"i","ns":"txntest.a","o":{"_id":0,"x":0},
+        "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}
+      }
+    ],
+    "ns": "txntest.a",
+    "postimage": [
+      {"_id":0,"x":0}
+    ]
+  },
+  "applyops not transaction": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.b","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"u","ns":"txntest.b","o":{"$set":{"x":1}},"o2":{"_id":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ]
+        }
+      }
+    ],
+    "ns": "txntest.b",
+    "postimage": [
+      {"_id":0,"x":1}
+    ]
+  },
+  "small, unprepared": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.c","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"u","ns":"txntest.c","o":{"$set":{"x":1}},"o2":{"_id":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"d","ns":"txntest.c","o":{"_id":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ]
+        },
+        "lsid":{"id":{"$binary":{"base64":"CK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+      }
+    ],
+    "ns": "txntest.c",
+    "postimage": [
+      {"_id":0,"x":1}
+    ]
+  },
+  "large, unprepared": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.d","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.d","o":{"_id":1,"x":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "partialTxn":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.d","o":{"_id":2,"x":2},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.d","o":{"_id":3,"x":3},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "partialTxn":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.d","o":{"_id":4,"x":4},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.d","o":{"_id":5,"x":5},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "count":6
+        },
+        "lsid":{"id":{"$binary":{"base64":"DK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+      }
+    ],
+    "ns": "txntest.d",
+    "postimage": [
+      {"_id":0,"x":0},
+      {"_id":1,"x":1},
+      {"_id":2,"x":2},
+      {"_id":3,"x":3},
+      {"_id":4,"x":4},
+      {"_id":5,"x":5}
+    ]
+  },
+  "small, prepared, committed": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.e","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.e","o":{"_id":1,"x":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"u","ns":"txntest.e","o":{"$set":{"x":1}},"o2":{"_id":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"d","ns":"txntest.e","o":{"_id":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "prepare":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"EK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "commitTransaction":1,
+          "commitTimestamp":{"$timestamp":{"t":1515616500,"i":11}}
+        },
+        "lsid":{"id":{"$binary":{"base64":"EK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+      }
+    ],
+    "ns": "txntest.e",
+    "postimage": [
+      {"_id":0,"x":1}
+    ]
+  },
+  "small, prepared, aborted": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.f","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.f","o":{"_id":1,"x":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.f","o":{"_id":2,"x":2},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"u","ns":"txntest.f","o":{"$set":{"x":1}},"o2":{"_id":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"d","ns":"txntest.f","o":{"_id":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "prepare":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"FK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{"abortTransaction":1 },
+        "lsid":{"id":{"$binary":{"base64":"FK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+      }
+    ],
+    "ns": "txntest.f",
+    "postimage": []
+  },
+  "large, prepared, committed": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.g","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":1,"x":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":2,"x":2},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "partialTxn":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.g","o":{"_id":3,"x":3},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":4,"x":4},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":5,"x":5},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "partialTxn":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.g","o":{"_id":6,"x":6},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":7,"x":7},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":8,"x":8},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.g","o":{"_id":9,"x":9},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "prepare":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "commitTransaction":1,
+          "commitTimestamp":{"$timestamp":{"t":1515616500,"i":11}}
+        },
+        "lsid":{"id":{"$binary":{"base64":"GK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+      }
+    ],
+    "ns": "txntest.g",
+    "postimage": [
+      {"_id":0,"x":0},
+      {"_id":1,"x":1},
+      {"_id":2,"x":2},
+      {"_id":3,"x":3},
+      {"_id":4,"x":4},
+      {"_id":5,"x":5},
+      {"_id":6,"x":6},
+      {"_id":7,"x":7},
+      {"_id":8,"x":8},
+      {"_id":9,"x":9}
+    ]
+  },
+  "large, prepared, aborted": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.h","o":{"_id":0,"x":0},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.h","o":{"_id":1,"x":1},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.h","o":{"_id":2,"x":2},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "partialTxn":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":0,"i":0}},"t":{"$numberLong":"-1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.h","o":{"_id":3,"x":3},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.h","o":{"_id":4,"x":4},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.h","o":{"_id":5,"x":5},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "partialTxn":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":3}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{
+          "applyOps":[
+            {"op":"i","ns":"txntest.h","o":{"_id":6,"x":6},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.h","o":{"_id":7,"x":7},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}},
+            {"op":"i","ns":"txntest.h","o":{"_id":8,"x":8},
+              "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}}}
+          ],
+          "prepare":true
+        },
+        "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":2}},"t":{"$numberLong":"1"}}
+      },
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":20}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"admin.$cmd",
+        "o":{"abortTransaction":1 },
+        "lsid":{"id":{"$binary":{"base64":"HK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"},
+        "prevOpTime":{"ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"} }
+      }
+    ],
+    "ns": "txntest.h",
+    "postimage": []
+  },
+  "not transaction with lsid": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"i","ns":"txntest.i","o":{"_id":0,"x":0},
+        "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}},
+        "lsid":{"id":{"$binary":{"base64":"IK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}}
+      }
+    ],
+    "ns": "txntest.i",
+    "postimage": [
+      {"_id":0,"x":0}
+    ]
+  },
+  "not transaction with lsid and txnNumber": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"i","ns":"txntest.j","o":{"_id":0,"x":0},
+        "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}},
+        "lsid":{"id":{"$binary":{"base64":"JK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"}
+      }
+    ],
+    "ns": "txntest.j",
+    "postimage": [
+      {"_id":0,"x":0}
+    ]
+  },
+  "not transaction with lsid and txnNumber and command": {
+    "ops": [
+      {
+        "ts":{"$timestamp":{"t":1515616500,"i":1}},"t":{"$numberLong":"1"},
+        "op":"c","ns":"txntest.$cmd", "o" : { "createIndexes" : "k", "v" : 2, "key" : { "x" : 1 }, "name" : "x_1" },
+        "ui":{"$binary":{"base64":"4p4kSLicSracQeNvveXz3g==","subType":"04"}},
+        "lsid":{"id":{"$binary":{"base64":"KK+8+nZ+Eem9p6vK9BEt9g==","subType":"04"}}},"txnNumber":{"$numberLong":"1"}
+      }
+    ],
+    "ns": "txntest.k",
+    "postimage": [ ]
+  },
+  "not transaction with multiOpType": {
+    "ops": [
+      {
+        "lsid": {
+          "id": { "$binary": "+0TxuFyBSeqjfJzju2Xl+w==", "$type": "04" },
+          "uid": { "$binary": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", "$type": "00" }
+        },
+        "txnNumber": { "$numberLong": "0" },
+        "op": "c",
+        "o": {
+          "applyOps": [ {
+            "op": "i",
+            "ns": "test.foo",
+            "ui": { "$binary": "iSa6jmEaQsK7Gjt4GfYQ7Q==", "$type": "04" },
+            "o": { "_id": 4, "x": -20, "y": 4 },
+            "destinedRecipient": "shard0"
+          },
+            {
+              "op": "i",
+              "ns": "test.foo",
+              "ui": { "$binary": "iSa6jmEaQsK7Gjt4GfYQ7Q==", "$type": "04" },
+              "o": { "_id": 5, "x": -30, "y": 11 },
+              "destinedRecipient": "shard1"
+            }
+          ]
+        },
+        "ts": { "$timestamp": { "t": 1609800491, "i": 1 } },
+        "t": { "$numberLong": "1" },
+        "wall": { "$date": "2021-01-04T17:48:11.237-05:00" },
+        "v": { "$numberLong": "2" },
+        "prevOpTime": {
+          "ts": { "$timestamp": { "t": 0, "i": 0 } },
+          "t": { "$numberLong": "-1" }
+        },
+        "multiOpType": 1
+      }
+    ],
+    "ns": "admin.$cmd"
+  }
+}

--- a/oplog/txn_meta.go
+++ b/oplog/txn_meta.go
@@ -48,6 +48,11 @@ type TxnMeta struct {
 // future if we change the db.Oplog.Object to bson.Raw, so the API is designed
 // with failure as a possibility.
 func NewTxnMeta(op ParsedLog) (TxnMeta, error) {
+	// If a vectored insert is within a retryable session, it will contain `lsid`, `txnNumber`, and `prevOpTime` fields
+	// and also a `multiOpType: 1` field which distinguishes vectored inserts from transactions.
+	if op.MultiOpType != nil && *op.MultiOpType == 1 {
+		return TxnMeta{}, nil
+	}
 	if op.LSID == nil || op.TxnNumber == nil || op.Operation != "c" {
 		return TxnMeta{}, nil
 	}

--- a/oplog/txn_test.go
+++ b/oplog/txn_test.go
@@ -1,0 +1,386 @@
+package oplog
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+const (
+	OplogEntriesFile = "testdata/oplog_entries.json"
+)
+
+var testCases = []*TestData{
+	{name: "not transaction", entryCount: 1, notTxn: true},
+	{name: "applyops not transaction", entryCount: 1, notTxn: true},
+	{name: "small, unprepared", entryCount: 1, innerOpCount: 3, commits: true},
+	{name: "large, unprepared", entryCount: 3, innerOpCount: 6, commits: true},
+	{name: "small, prepared, committed", entryCount: 2, innerOpCount: 4, commits: true},
+	{name: "small, prepared, aborted", entryCount: 2, innerOpCount: 5, aborts: true},
+	{name: "large, prepared, committed", entryCount: 4, innerOpCount: 10, commits: true},
+	{name: "large, prepared, aborted", entryCount: 4, innerOpCount: 9, aborts: true},
+	{name: "not transaction with lsid", entryCount: 1, notTxn: true},
+	{name: "not transaction with lsid and txnNumber", entryCount: 1, notTxn: true},
+	{name: "not transaction with lsid and txnNumber and command", entryCount: 1, notTxn: true},
+	{name: "not transaction with multiOpType", entryCount: 1, notTxn: true},
+}
+
+type TestData struct {
+	name         string
+	entryCount   int
+	innerOpCount int
+	notTxn       bool
+	commits      bool
+	aborts       bool
+	ops          []ParsedLog
+}
+
+func readTestData() (bson.Raw, error) {
+	b, err := os.ReadFile(OplogEntriesFile)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load %s: %v", OplogEntriesFile, err)
+	}
+	var data bson.Raw
+	err = bson.UnmarshalExtJSON(b, false, &data)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't decode JSON: %v", err)
+	}
+	return data, nil
+}
+func getOpsForCase(name string, data bson.Raw) ([]ParsedLog, error) {
+	rawArray, err := data.LookupErr(name, "ops")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't find ops for case %s: %v", name, err)
+	}
+	rawOps, err := rawArray.Array().Elements()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't extract array elements for case %s: %v", name, err)
+	}
+	ops := make([]ParsedLog, len(rawOps))
+	for i, e := range rawOps {
+		err := e.Value().Unmarshal(&ops[i])
+		if err != nil {
+			return nil, fmt.Errorf("couldn't unmarshal op %d for case %s: %v", i, name, err)
+		}
+	}
+	return ops, nil
+}
+func mapTestTxnByID() (map[TxnID]*TestData, error) {
+	m := make(map[TxnID]*TestData)
+	for _, c := range testCases {
+		meta, err := NewTxnMeta(c.ops[0])
+		if err != nil {
+			return nil, err
+		}
+		if meta.IsTxn() {
+			m[meta.id] = c
+		}
+	}
+	return m, nil
+}
+func TestMain(m *testing.M) {
+	flag.Parse()
+	data, err := readTestData()
+	if err != nil {
+		panic(err)
+	}
+	for i, c := range testCases {
+		ops, err := getOpsForCase(c.name, data)
+		if err != nil {
+			panic(err)
+		}
+		// c is a copy and we want to change the original
+		testCases[i].ops = ops
+	}
+	os.Exit(m.Run())
+}
+
+//------------- fot txn_meta.go ----------------
+func TestTxnMeta(t *testing.T) {
+	for _, c := range testCases {
+		t.Run(c.name, func(*testing.T) {
+			if c.notTxn {
+				runNonTxnMetaCase(t, c)
+			} else {
+				runTxnMetaCase(t, c)
+			}
+		})
+	}
+}
+func runNonTxnMetaCase(t *testing.T, c *TestData) {
+	meta, err := NewTxnMeta(c.ops[0])
+	if err != nil {
+		t.Fatalf("case %s: failed to parse op: %v", c.name, err)
+	}
+	if meta.IsTxn() {
+		t.Errorf("case %s: non-txn meta looks like transaction", c.name)
+	}
+	return
+}
+func runTxnMetaCase(t *testing.T, c *TestData) {
+	ops := c.ops
+	// Double check that we get all the ops we expected.
+	if len(ops) != c.entryCount {
+		t.Errorf("case %s: expected %d ops, but got %d", c.name, c.entryCount, len(ops))
+	}
+	// Test properties of each op.
+	for i, o := range ops {
+		meta, err := NewTxnMeta(o)
+		if err != nil {
+			t.Fatalf("case %s [%d]: failed to parse op: %v", c.name, i, err)
+		}
+		if (meta.id == TxnID{}) {
+			t.Errorf("case %s [%d]: Id was zero value", c.name, i)
+		}
+		isMultiOp := c.entryCount > 1
+		if meta.IsMultiOp() != isMultiOp {
+			t.Errorf(
+				"case %s [%d]: expected IsMultiOp %v, but got %v",
+				c.name,
+				i,
+				meta.IsMultiOp(),
+				isMultiOp,
+			)
+		}
+		if i == 0 {
+			if !meta.IsData() {
+				t.Errorf("case %s [%d]: op should have parsed as data, but it wasn't", c.name, i)
+			}
+		}
+		if i != len(ops)-1 {
+			if meta.IsFinal() {
+				t.Errorf("case %s [%d]: op parsed as final, but it wasn't", c.name, i)
+			}
+		}
+	}
+	// Test properties of the last op.
+	lastOp := ops[len(ops)-1]
+	meta, _ := NewTxnMeta(lastOp)
+	if !meta.IsFinal() {
+		t.Errorf("case %s: last oplog entry not marked final", c.name)
+	}
+	if c.commits && !meta.IsCommit() {
+		t.Errorf("case %s: expected last oplog entry to be a commit but it wasn't", c.name)
+	}
+	if c.aborts && !meta.IsAbort() {
+		t.Errorf("case %s: expected last oplog entry to be a abort but it wasn't", c.name)
+	}
+}
+
+//------------- fot txn_buffer.go ----------------
+// test each type of transaction individually and serially.
+func TestSingleTxnBuffer(t *testing.T) {
+	buffer := NewBuffer()
+	txnByID, err := mapTestTxnByID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			testBufferOps(t, buffer, c.ops, txnByID)
+		})
+	}
+}
+func TestMixedTxnBuffer(t *testing.T) {
+	buffer := NewBuffer()
+	txnByID, err := mapTestTxnByID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	streams := make([][]ParsedLog, len(testCases))
+	for i, c := range testCases {
+		streams[i] = c.ops
+	}
+	ops := mergeOplogStreams(streams)
+	testBufferOps(t, buffer, ops, txnByID)
+}
+func testBufferOps(t *testing.T, buffer *TxnBuffer, ops []ParsedLog, txnByID map[TxnID]*TestData) {
+	innerOpCounter := make(map[TxnID]int)
+	for _, op := range ops {
+		meta, _ := NewTxnMeta(op)
+		if !meta.IsTxn() {
+			return
+		}
+		err := buffer.AddOp(meta, op)
+		if err != nil {
+			t.Fatalf("AddOp failed: %v", err)
+		}
+		if meta.IsAbort() {
+			err := buffer.PurgeTxn(meta)
+			if err != nil {
+				t.Fatalf("PurgeTxn (abort) failed: %v", err)
+			}
+			assertNoStateForID(t, meta, buffer)
+			continue
+		}
+		if !meta.IsCommit() {
+			continue
+		}
+		// From here, we're simulating "applying" transaction entries
+		ops, errs := buffer.GetTxnStream(meta)
+	LOOP:
+		for {
+			select {
+			case _, ok := <-ops:
+				if !ok {
+					break LOOP
+				}
+				innerOpCounter[meta.id]++
+			case err := <-errs:
+				if err != nil {
+					t.Fatalf("GetTxnStream streaming failed: %v", err)
+				}
+				break LOOP
+			}
+		}
+		expectedCnt := txnByID[meta.id].innerOpCount
+		if innerOpCounter[meta.id] != expectedCnt {
+			t.Errorf(
+				"incorrect streamed op count; got %d, expected %d",
+				innerOpCounter[meta.id],
+				expectedCnt,
+			)
+		}
+		err = buffer.PurgeTxn(meta)
+		if err != nil {
+			t.Fatalf("PurgeTxn (commit) failed: %v", err)
+		}
+		assertNoStateForID(t, meta, buffer)
+	}
+}
+
+// MergeOplogStreams combines oplog arrays such that the order of entries is
+// random, but order-preserving with respect to each initial stream.
+func mergeOplogStreams(input [][]ParsedLog) []ParsedLog {
+	// Copy input op arrays so we can destructively shuffle them together
+	streams := make([][]ParsedLog, len(input))
+	opCount := 0
+	for i, v := range input {
+		streams[i] = make([]ParsedLog, len(v))
+		copy(streams[i], v)
+		opCount += len(v)
+	}
+	ops := make([]ParsedLog, 0, opCount)
+	for len(streams) != 0 {
+		// randomly pick a stream to add an op
+		rand.Shuffle(len(streams), func(i, j int) {
+			streams[i], streams[j] = streams[j], streams[i]
+		})
+		ops = append(ops, streams[0][0])
+		// remove the op and its stream if empty
+		streams[0] = streams[0][1:]
+		if len(streams[0]) == 0 {
+			streams = streams[1:]
+		}
+	}
+	return ops
+}
+func assertNoStateForID(t *testing.T, meta TxnMeta, buffer *TxnBuffer) {
+	_, ok := buffer.txns[meta.id]
+	if ok {
+		t.Errorf("state not cleared for %v", meta.id)
+	}
+}
+func TestOldestTimestamp(t *testing.T) {
+	buffer := NewBuffer()
+	// With no transactions, oldest active is zero value
+	oldest := buffer.OldestOpTime()
+	zeroTimestamp := primitive.Timestamp{}
+	if oldest.Timestamp != zeroTimestamp {
+		t.Errorf("expected zero timestamp, but got %v", oldest.Timestamp)
+	}
+	// Constructing manually requires pointers to int64, so they can't be constants.
+	txnN := []int64{0, 1}
+	ops := []ParsedLog{
+		{
+			Timestamp: primitive.Timestamp{T: 1234, I: 1},
+			LSID:      bson.Raw{0, 0, 0, 0, 1},
+			TxnNumber: &txnN[0],
+			Operation: "c",
+			Namespace: "admin.$cmd",
+			Object: bson.D{
+				{"applyOps", bson.A{bson.D{{"op", "n"}}}},
+				{"partialTxn", true},
+			},
+		},
+		{
+			Timestamp: primitive.Timestamp{T: 1235, I: 1},
+			LSID:      bson.Raw{0, 0, 0, 0, 2},
+			TxnNumber: &txnN[1],
+			Operation: "c",
+			Namespace: "admin.$cmd",
+			Object: bson.D{
+				{"applyOps", bson.A{bson.D{{"op", "n"}}}},
+				{"partialTxn", true},
+			},
+		},
+		{
+			Timestamp: primitive.Timestamp{T: 1236, I: 1},
+			LSID:      bson.Raw{0, 0, 0, 0, 1},
+			TxnNumber: &txnN[0],
+			Operation: "c",
+			Namespace: "admin.$cmd",
+			Object: bson.D{
+				{"applyOps", bson.A{bson.D{{"op", "n"}}}},
+				{"partialTxn", true},
+			},
+		},
+	}
+	for _, v := range ops {
+		meta, err := NewTxnMeta(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = buffer.AddOp(meta, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// With uncommitted transactions, we should see the oldest among them.
+	oldest = buffer.OldestOpTime()
+	expect := primitive.Timestamp{T: 1234, I: 1}
+	if oldest.Timestamp != expect {
+		t.Fatalf("expected timestamp %v, but got %v", expect, oldest)
+	}
+}
+func TestExtractInnerOps(t *testing.T) {
+	// Constructing manually requires pointers to int64, so they can't be constants.
+	txnN := []int64{0}
+	term := []int64{1}
+	hash := []int64{2}
+	timestamp := primitive.Timestamp{T: 1234, I: 1}
+	Convey(
+		"extracted oplogs from transaction oplog should have the same timestamp, term and hash",
+		t,
+		func() {
+			op := ParsedLog{
+				Timestamp: primitive.Timestamp{T: 1234, I: 1},
+				Term:      &term[0],
+				Hash:      &hash[0],
+				LSID:      bson.Raw{0, 0, 0, 0, 1},
+				TxnNumber: &txnN[0],
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					{"applyOps", bson.A{bson.D{{"op", "n"}}}},
+					{"partialTxn", true},
+				},
+			}
+			innerOps, err := ExtractInnerOps(&op)
+			if err != nil {
+				t.Fatalf("PurgeTxn (abort) failed: %v", err)
+			}
+			for _, innerOp := range innerOps {
+				So(innerOp.Timestamp, ShouldEqual, timestamp)
+				So(*innerOp.Term, ShouldEqual, term[0])
+				So(*innerOp.Hash, ShouldEqual, hash[0])
+			}
+		},
+	)
+}

--- a/scripts/mongo-shake-progress.sh
+++ b/scripts/mongo-shake-progress.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# Script to fetch and format mongo-shake progress information for the FULL phase.
+#
+# Usage: mongo-shake-stats.sh <mongo_shake_url>
+#
+
+# Default URL if not provided
+MONGO_SHAKE_URL=${1:-"http://localhost:9101"}
+
+# Remove trailing slash if present
+MONGO_SHAKE_URL=${MONGO_SHAKE_URL%/}
+
+echo
+
+# Fetch progress from the API
+# Example JSON:
+# {"progress":"26.14%","total_collection_number":88,"finished_collection_number":23,"processing_collection_number":4,"wait_collection_number":61,"collection_metric":{"ns.coll1":"100% (0/0)","ns.coll2":"-","ns.coll3":"50% (500/1000)"}}
+progress_output=$(curl -s "$MONGO_SHAKE_URL/progress")
+
+if [ -z "$progress_output" ]; then
+    echo "Error: Failed to fetch progress information from $MONGO_SHAKE_URL/progress"
+    exit 1
+fi
+
+# Format and display the progress
+echo "Collections: Total=$(echo $progress_output | jq -r '.total_collection_number'), Finished=$(echo $progress_output | jq -r '.finished_collection_number') ($(echo $progress_output | jq -r '.progress')), Processing=$(echo $progress_output | jq -r '.processing_collection_number'), Waiting=$(echo $progress_output | jq -r '.wait_collection_number')"
+
+echo
+echo "In progress ($(echo $progress_output | jq -r '.processing_collection_number'))"
+echo
+(
+  echo $progress_output | jq -r '.collection_metric | to_entries[] | select(.value | test("^[0-9][0-9]?(.[0-9]{2})?%")) | "\(.key) \(.value)"'
+) | column -t -s ' '
+
+# List finished collections
+echo
+echo "Finished ($(echo $progress_output | jq -r '.finished_collection_number'))"
+echo
+echo "$progress_output" | jq -r '.collection_metric | to_entries[] | select(.value | test("^100(.00)?%")) | .key' | pr -4 -t -w "$(tput cols)" | column -t
+
+# List not started collections
+echo
+echo "Not started ($(echo $progress_output | jq -r '.wait_collection_number'))"
+echo
+echo "$progress_output" | jq -r '.collection_metric | to_entries[] | select(.value == "-") | .key' | pr -4 -t -w "$(tput cols)" | column -t

--- a/scripts/mongo-shake-stat.sh
+++ b/scripts/mongo-shake-stat.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# Script to fetch and format mongo-shake stats information for the incremental replication phase
+#
+# Usage: mongo-shake-stats.sh <mongo_shake_url>
+
+# Default URL if not provided
+MONGO_SHAKE_URL=${1:-"http://localhost:9100"}
+
+# Remove trailing slash if present
+MONGO_SHAKE_URL=${MONGO_SHAKE_URL%/}
+
+# Fetch replication state
+# Example JSON:
+# {"who":"mongoshake","tag":",b05864e209f3901fc026189452e0a5c0214d7bdf,release,go1.18.3,2025-06-30_15:03:46","replset":"rs0","logs_get":152235,"logs_repl":85447,"logs_success":85447,"tps":0,"lsn":{"unix":1751998421,"time":"2025-07-08 18:13:41","ts":"7524775920838639618"},"lsn_ack":{"unix":1751998421,"time":"2025-07-08 18:13:41","ts":"7524775920838639618"},"lsn_ckpt":{"unix":1751999717,"time":"2025-07-08 18:35:17","ts":"7524781487116255233"},"now":{"unix":1751999800,"time":"2025-07-08 18:36:40"},"log_size_avg":"466.00B","log_size_max":"4.21KB"}
+# Example table format:
+
+REPL_RESPONSE=$(curl -s "$MONGO_SHAKE_URL/repl")
+
+# Display replication status table
+echo
+echo "Replication status:"
+echo
+
+(
+  echo "$REPL_RESPONSE" | \
+    jq -r '{"who": .who, "tag": .tag, "replset": .replset, "logs_get": .logs_get, "logs_repl": .logs_repl, "logs_success": .logs_success, "tps": .tps, "log_size_avg": .log_size_avg, "log_size_max": .log_size_max} | to_entries | .[] | "\(.key) | \(.value)"'
+) | column -t -s'|' || echo "Error: Failed to parse metadata"
+
+# lsn.ts                 lsn.ts_unix    lsn.ts_unix
+# 7524775920838639618    1751998421     2025-07-08 18:13:41
+# 7524775920838639618    1751998421     2025-07-08 18:13:41
+# 7524783870823104513    1752000272     2025-07-08 18:44:32
+
+echo
+echo "LSN Information:"
+echo
+
+(
+ echo "lsn.ts | lsn.ts_unix | lsn.ts_unix"
+ echo "$REPL_RESPONSE" | \
+   jq -r '[["lsn", .lsn], ["lsn_ack", .lsn_ack], ["lsn_ckpt", .lsn_ckpt]] | .[] | "\(.[1].ts) | \(.[1].unix) | \(.[1].time)"'
+) | column -t -s'|' || echo "Error: Failed to fetch or parse mongo-shake stats"
+
+# Fetch worker state
+# Example JSON:
+# [{"worker_id":0,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524743755828559875","last_ack":"7524743755828559875","count":65655},{"worker_id":1,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524709039607906306","last_ack":"7524709039607906306","count":43},{"worker_id":2,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524775920838639617","last_ack":"7524775920838639617","count":9889},{"worker_id":3,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524775697500340225","last_ack":"7524775697500340225","count":426},{"worker_id":4,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524723569482268674","last_ack":"7524723569482268674","count":8052},{"worker_id":5,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524775920838639618","last_ack":"7524775920838639618","count":1339},{"worker_id":6,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524517299382910978","last_ack":"7524517299382910978","count":5},{"worker_id":7,"jobs_in_queue":0,"jobs_unack_buffer":0,"last_unack":"7524723775640698881","last_ack":"7524723775640698881","count":38}]
+# Example table format
+# worker_id    jobs_in_queue    jobs_unack_buffer    last_unack             last_ack               count
+# 0            0                0                    7524743755828559875    7524743755828559875    65655
+# 1            0                0                    7524709039607906306    7524709039607906306    43
+# 2            0                0                    7524775920838639617    7524775920838639617    9889
+# 3            0                0                    7524775697500340225    7524775697500340225    426
+# 4            0                0                    7524723569482268674    7524723569482268674    8052
+echo
+echo "Worker Information:"
+echo
+(
+ echo "worker_id | jobs_in_queue | jobs_unack_buffer | last_unack | last_ack | count"
+ curl -s "$MONGO_SHAKE_URL/worker" | \
+   jq -r '.[] | "\(.worker_id) | \(.jobs_in_queue) | \(.jobs_unack_buffer) | \(.last_unack) | \(.last_ack) | \(.count)"'
+) | column -t -s'|' || echo "Error: Failed to fetch or parse mongo-shake worker stats"

--- a/third_party/log4go/termlog.go
+++ b/third_party/log4go/termlog.go
@@ -32,8 +32,30 @@ func (c *ConsoleLogWriter) SetFormat(format string) {
 	c.format = format
 }
 func (c *ConsoleLogWriter) run(out io.Writer) {
-	for rec := range c.w {
-		fmt.Fprint(out, FormatLogRecord(c.format, rec))
+	//for rec := range c.w {
+	//	fmt.Fprint(out, FormatLogRecord(c.format, rec))
+	//}
+	for {
+		select {
+		case rec, ok := <-c.w:
+			if !ok {
+				return
+			}
+			fmt.Fprint(out, FormatLogRecord(c.format, rec))
+		case <-c.done:
+			// drain remaining messages
+			for {
+				select {
+				case rec, ok := <-c.w:
+					if !ok {
+						return
+					}
+					fmt.Fprint(out, FormatLogRecord(c.format, rec))
+				default:
+					return
+				}
+			}
+		}
 	}
 }
 
@@ -53,6 +75,6 @@ func (c *ConsoleLogWriter) LogWrite(rec *LogRecord) {
 // send log messages to this logger after a Close have undefined behavior.
 func (c *ConsoleLogWriter) Close() {
 	close(c.done)
-	close(c.w)
+	// close(c.w)
 	time.Sleep(50 * time.Millisecond) // Try to give console I/O time to complete
 }

--- a/tunnel/kafka/common.go
+++ b/tunnel/kafka/common.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"compress/gzip"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/rcrowley/go-metrics"
 
+	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	utils "github.com/alibaba/MongoShake/v2/common"
 	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
 )
@@ -43,6 +45,14 @@ func NewConfig(rootCaFile string) (*Config, error) {
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 	config.Producer.MaxMessageBytes = 16*utils.MB + 2*utils.MB // 2MB for the reserve gap
 
+	if conf.Options.KafkaProducerMaxMessage > 0 {
+		config.Producer.MaxMessageBytes = conf.Options.KafkaProducerMaxMessage
+	}
+	config.Producer.Compression = getKafkaCompression(conf.Options.TunnelKafkaCompression) // conf.Options.TunnelKafkaCompression
+	if config.Producer.Compression == sarama.CompressionGZIP {
+		config.Producer.CompressionLevel = gzip.BestCompression
+	}
+
 	// ssl
 	if rootCaFile != "" {
 		sslConfig := &tls.Config{
@@ -58,6 +68,30 @@ func NewConfig(rootCaFile string) (*Config, error) {
 		sslConfig.RootCAs = caCertPool
 		config.Net.TLS.Config = sslConfig
 		config.Net.TLS.Enable = true
+	}
+
+	if conf.Options.TunnelKafkaSaslEnable {
+		user, pwd, _ := parseAuth(conf.Options.TunnelKafkaSaslAuth)
+		config.Metadata.Full = false
+		config.Net.SASL.Enable = true
+		config.Net.SASL.User = user
+		config.Net.SASL.Password = pwd
+		saslMechanismOption := conf.Options.TunnelKafkaSaslMechanism
+		if saslMechanismOption != "" {
+			saslMechanism := sarama.SASLMechanism(saslMechanismOption)
+			config.Net.SASL.Mechanism = saslMechanism
+			switch saslMechanism {
+			case sarama.SASLTypeSCRAMSHA256:
+				//sarama.SASLTypeSCRAMSHA256
+				config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+					return &XDGSCRAMClient{HashGeneratorFcn: SHA256}
+				}
+			case sarama.SASLTypeSCRAMSHA512:
+				config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+					return &XDGSCRAMClient{HashGeneratorFcn: SHA512}
+				}
+			}
+		}
 	}
 
 	return &Config{
@@ -80,4 +114,30 @@ func parse(address string) (string, []string, error) {
 
 	brokers := strings.Split(arr[l-1], brokersSplitter)
 	return topic, brokers, nil
+}
+
+// parse the auth (user@pwd)
+func parseAuth(auth string) (string, string, error) {
+	arr := strings.Split(auth, topicSplitter)
+	l := len(arr)
+	if l != 2 {
+		return "", "", fmt.Errorf("auth format error")
+	}
+	return arr[0], arr[1], nil
+}
+
+//getKafkaCompression 根据kafkaCompression值获取对应的枚举
+func getKafkaCompression(compression string) sarama.CompressionCodec {
+	compressions := map[string]sarama.CompressionCodec{
+		"none":   sarama.CompressionNone,
+		"gzip":   sarama.CompressionGZIP,
+		"snappy": sarama.CompressionSnappy,
+		"lz4":    sarama.CompressionLZ4,
+		"zstd":   sarama.CompressionZSTD,
+	}
+	if result, ok := compressions[compression]; !ok {
+		return sarama.CompressionNone
+	} else {
+		return result
+	}
 }

--- a/tunnel/kafka/saram_client.go
+++ b/tunnel/kafka/saram_client.go
@@ -1,0 +1,37 @@
+package kafka
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/xdg-go/scram"
+)
+
+var (
+	SHA256 scram.HashGeneratorFcn = sha256.New
+	SHA512 scram.HashGeneratorFcn = sha512.New
+)
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/unit_test_common/include.go
+++ b/unit_test_common/include.go
@@ -1,12 +1,14 @@
 package unit_test_common
 
 const (
-	TestUrl                 = "mongodb://100.81.164.181:18201,100.81.164.181:18202,100.81.164.181:18203"
-	TestUrl4_4              = "100.81.164.181:35309"
-	TestUrlServerless       = "mongodb://100.81.164.181:19031"
-	TestUrlConfigServer     = "mongodb://100.81.164.181:19021"
-	TestUrlServerlessTenant = "mongodb://100.81.164.181:19031" // sharding mongos with tenant
-	TestUrlSharding         = "mongodb://100.81.164.181:19031"
-	TestUrlSsl              = "mongodb://100.81.164.181:18101,100.81.164.181:18102,100.81.164.181:18103"
-	TestUrl5_0              = "mongodb://100.81.164.181:18301,100.81.164.181:18302,100.81.164.181:18303"
+	//TestUrl                 = "mongodb://100.81.164.181:18201,100.81.164.181:18202,100.81.164.181:18203"
+	//TestUrlConfigServer     = "mongodb://100.81.164.181:19021"
+	//TestUrlServerlessTenant = "mongodb://100.81.164.181:19031" // sharding mongos with tenant
+	//TestUrlSharding         = "mongodb://100.81.164.181:19031"
+	//TestUrlSsl              = "mongodb://100.81.164.181:18101,100.81.164.181:18102,100.81.164.181:18103"
+	TestUrl                 = "mongodb://root:MongoDB2022@11.158.213.66:40000,11.158.213.66:40001,11.158.213.66:40002/admin"
+	TestUrlConfigServer     = "mongodb://admin:admin@11.158.213.66:38100"
+	TestUrlServerlessTenant = "mongodb://admin:admin@11.158.213.66:38200"
+	TestUrlSharding         = "mongodb://admin:admin@11.158.213.66:38200"
+	TestUrlSsl              = "mongodb://47.102.27.138:3717"
 )

--- a/unit_test_common/include.go
+++ b/unit_test_common/include.go
@@ -1,12 +1,9 @@
 package unit_test_common
 
 const (
-	//TestUrl                 = "mongodb://100.81.164.181:18201,100.81.164.181:18202,100.81.164.181:18203"
-	//TestUrlConfigServer     = "mongodb://100.81.164.181:19021"
-	//TestUrlServerlessTenant = "mongodb://100.81.164.181:19031" // sharding mongos with tenant
-	//TestUrlSharding         = "mongodb://100.81.164.181:19031"
-	//TestUrlSsl              = "mongodb://100.81.164.181:18101,100.81.164.181:18102,100.81.164.181:18103"
-	TestUrl                 = "mongodb://root:MongoDB2022@11.158.213.66:40000,11.158.213.66:40001,11.158.213.66:40002/admin"
+	//TestUrl = "mongodb://root:MongoDB2022@11.158.213.66:40000,11.158.213.66:40001,11.158.213.66:40002/admin"
+	TestUrl = "mongodb://root_special_char3:~!@#$^&*()_-=@11.158.213.66:40000,11.158.213.66:40001,11.158.213.66:40002/admin"
+
 	TestUrlConfigServer     = "mongodb://admin:admin@11.158.213.66:38100"
 	TestUrlServerlessTenant = "mongodb://admin:admin@11.158.213.66:38200"
 	TestUrlSharding         = "mongodb://admin:admin@11.158.213.66:38200"


### PR DESCRIPTION
    * version: 2.8.7
    * FEATURE: add new option incr_sync.executor.bypass_document_validation
    * BUGFIX: #924, rm useless Mkdirs() in main
    * BUGFIX: #925, run splitVector failed due to 'Decode to nil value'
    * BUGFIX: avoid 'ReadConcernMajorityNotEnabled' error in ckptManager for MongoDB3.6-
    * IMPROVE: log4go support drain remaining log messages
    * BUGFIX: #928, NamespaceFilter use bson.A instead of []interface{} to handle remainOps
    * IMPROVE: handle 'update document must contain key beginning with '$'' error
    * FEATURE: update txn meta to support vectored insert oplog format with 'multiOpType' field
    * REFINE: change default value of full_sync.create_index to background
    * FEATURE: PR#820, add kafka SSL support (thanks @renheqiang)
    * FEATURE: #914, add two shell scripts to print progress/stat (thanks @dobesv)
    * BUGFIX: #834, init ckptMap correctly with changeStream mode
    * FEATURE: #926, support mongodb uri with special characters
    * BUGFIX: #925, run splitVector correctly (thanks @pengzhenyi2015)
    * IMPROVE: #923, add full_sync.reader.split_max_chunk_size in conf with default 1024MB
    * IMPROVE: #933, Filter support config.system.preimages
    * BUGFIX: #897, time-series collections could not use hint (not done)