### PR TITLE
Support filtering oplog by op type with filter.cmds

### DIFF
--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -2,11 +2,20 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/filter"
 	utils "github.com/alibaba/MongoShake/v2/common"
 )
+
+var validFilterCmds = map[string]struct{}{
+	"i": {},
+	"u": {},
+	"d": {},
+	"c": {},
+	"n": {},
+}
 
 // priority use mongo_s_url
 func getSourceDbUrl() (string, error) {
@@ -98,6 +107,11 @@ func checkDefaultValue() error {
 	if conf.Options.LogFileName == "" {
 		conf.Options.LogFileName = "mongoshake.log"
 	}
+	filterCmds, err := normalizeFilterCmds(conf.Options.FilterCmds)
+	if err != nil {
+		return err
+	}
+	conf.Options.FilterCmds = filterCmds
 
 	if conf.Options.SyncMode == "" {
 		conf.Options.SyncMode = utils.VarSyncModeIncr
@@ -292,6 +306,21 @@ func checkDefaultValue() error {
 	filter.NsShouldBeIgnore[utils.APPConflictDatabase+"."] = true
 
 	return nil
+}
+
+func normalizeFilterCmds(cmds []string) ([]string, error) {
+	out := make([]string, 0, len(cmds))
+	for _, cmd := range cmds {
+		cmd = strings.TrimSpace(strings.ToLower(cmd))
+		if cmd == "" {
+			continue
+		}
+		if _, ok := validFilterCmds[cmd]; !ok {
+			return nil, fmt.Errorf("filter.cmds[%s] should in {i, u, d, c, n}", cmd)
+		}
+		out = append(out, cmd)
+	}
+	return out, nil
 }
 
 func checkConnection() error {

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -14,8 +14,9 @@ var validFilterCmds = map[string]struct{}{
 	"u": {},
 	"d": {},
 	"c": {},
-	"n": {},
 }
+
+const validFilterCmdsText = "{i, u, d, c}"
 
 // priority use mongo_s_url
 func getSourceDbUrl() (string, error) {
@@ -315,8 +316,11 @@ func normalizeFilterCmds(cmds []string) ([]string, error) {
 		if cmd == "" {
 			continue
 		}
+		if cmd == "n" {
+			return nil, fmt.Errorf("filter.cmds: unsupported op type %q; noop oplogs are already filtered by the built-in NoopFilter", cmd)
+		}
 		if _, ok := validFilterCmds[cmd]; !ok {
-			return nil, fmt.Errorf("filter.cmds[%s] should in {i, u, d, c, n}", cmd)
+			return nil, fmt.Errorf("filter.cmds: unknown op type %q, must be one of %s", cmd, validFilterCmdsText)
 		}
 		out = append(out, cmd)
 	}

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -9,14 +9,14 @@ import (
 	utils "github.com/alibaba/MongoShake/v2/common"
 )
 
-var validFilterCmds = map[string]struct{}{
+var validFilterOpTypes = map[string]struct{}{
 	"i": {},
 	"u": {},
 	"d": {},
 	"c": {},
 }
 
-const validFilterCmdsText = "{i, u, d, c}"
+const validFilterOpTypesText = "{i, u, d, c}"
 
 // priority use mongo_s_url
 func getSourceDbUrl() (string, error) {
@@ -108,11 +108,11 @@ func checkDefaultValue() error {
 	if conf.Options.LogFileName == "" {
 		conf.Options.LogFileName = "mongoshake.log"
 	}
-	filterCmds, err := normalizeFilterCmds(conf.Options.FilterCmds)
+	filterOpTypes, err := normalizeFilterOpTypes(conf.Options.FilterOpTypes)
 	if err != nil {
 		return err
 	}
-	conf.Options.FilterCmds = filterCmds
+	conf.Options.FilterOpTypes = filterOpTypes
 
 	if conf.Options.SyncMode == "" {
 		conf.Options.SyncMode = utils.VarSyncModeIncr
@@ -309,20 +309,20 @@ func checkDefaultValue() error {
 	return nil
 }
 
-func normalizeFilterCmds(cmds []string) ([]string, error) {
-	out := make([]string, 0, len(cmds))
-	for _, cmd := range cmds {
-		cmd = strings.TrimSpace(strings.ToLower(cmd))
-		if cmd == "" {
+func normalizeFilterOpTypes(opTypes []string) ([]string, error) {
+	out := make([]string, 0, len(opTypes))
+	for _, opType := range opTypes {
+		opType = strings.TrimSpace(strings.ToLower(opType))
+		if opType == "" {
 			continue
 		}
-		if cmd == "n" {
-			return nil, fmt.Errorf("filter.cmds: unsupported op type %q; noop oplogs are already filtered by the built-in NoopFilter", cmd)
+		if opType == "n" {
+			return nil, fmt.Errorf("filter.op_types: unsupported op type %q; noop oplogs are already filtered by the built-in NoopFilter", opType)
 		}
-		if _, ok := validFilterCmds[cmd]; !ok {
-			return nil, fmt.Errorf("filter.cmds: unknown op type %q, must be one of %s", cmd, validFilterCmdsText)
+		if _, ok := validFilterOpTypes[opType]; !ok {
+			return nil, fmt.Errorf("filter.op_types: unknown op type %q, must be one of %s", opType, validFilterOpTypesText)
 		}
-		out = append(out, cmd)
+		out = append(out, opType)
 	}
 	return out, nil
 }

--- a/cmd/collector/sanitize_test.go
+++ b/cmd/collector/sanitize_test.go
@@ -8,28 +8,28 @@ import (
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 )
 
-func TestNormalizeFilterCmds(t *testing.T) {
-	cmds, err := normalizeFilterCmds([]string{" d ", "I", "", "  "})
+func TestNormalizeFilterOpTypes(t *testing.T) {
+	opTypes, err := normalizeFilterOpTypes([]string{" d ", "I", "", "  "})
 	assert.NoError(t, err, "should be equal")
-	assert.Equal(t, []string{"d", "i"}, cmds, "should be equal")
+	assert.Equal(t, []string{"d", "i"}, opTypes, "should be equal")
 }
 
-func TestNormalizeFilterCmdsRejectNoop(t *testing.T) {
-	cmds, err := normalizeFilterCmds([]string{"n"})
-	assert.Nil(t, cmds, "should be equal")
-	assert.EqualError(t, err, `filter.cmds: unsupported op type "n"; noop oplogs are already filtered by the built-in NoopFilter`)
+func TestNormalizeFilterOpTypesRejectNoop(t *testing.T) {
+	opTypes, err := normalizeFilterOpTypes([]string{"n"})
+	assert.Nil(t, opTypes, "should be equal")
+	assert.EqualError(t, err, `filter.op_types: unsupported op type "n"; noop oplogs are already filtered by the built-in NoopFilter`)
 }
 
-func TestCheckDefaultValueInvalidFilterCmds(t *testing.T) {
+func TestCheckDefaultValueInvalidFilterOpTypes(t *testing.T) {
 	origin := conf.Options
 	defer func() {
 		conf.Options = origin
 	}()
 
 	conf.Options = conf.Configuration{
-		FilterCmds: []string{"delete"},
+		FilterOpTypes: []string{"delete"},
 	}
 
 	err := checkDefaultValue()
-	assert.EqualError(t, err, `filter.cmds: unknown op type "delete", must be one of {i, u, d, c}`)
+	assert.EqualError(t, err, `filter.op_types: unknown op type "delete", must be one of {i, u, d, c}`)
 }

--- a/cmd/collector/sanitize_test.go
+++ b/cmd/collector/sanitize_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	conf "github.com/alibaba/MongoShake/v2/collector/configure"
+)
+
+func TestNormalizeFilterCmds(t *testing.T) {
+	cmds, err := normalizeFilterCmds([]string{" d ", "I", "", "  ", "n"})
+	assert.NoError(t, err, "should be equal")
+	assert.Equal(t, []string{"d", "i", "n"}, cmds, "should be equal")
+}
+
+func TestCheckDefaultValueInvalidFilterCmds(t *testing.T) {
+	origin := conf.Options
+	defer func() {
+		conf.Options = origin
+	}()
+
+	conf.Options = conf.Configuration{
+		FilterCmds: []string{"delete"},
+	}
+
+	err := checkDefaultValue()
+	assert.EqualError(t, err, "filter.cmds[delete] should in {i, u, d, c, n}")
+}

--- a/cmd/collector/sanitize_test.go
+++ b/cmd/collector/sanitize_test.go
@@ -9,9 +9,15 @@ import (
 )
 
 func TestNormalizeFilterCmds(t *testing.T) {
-	cmds, err := normalizeFilterCmds([]string{" d ", "I", "", "  ", "n"})
+	cmds, err := normalizeFilterCmds([]string{" d ", "I", "", "  "})
 	assert.NoError(t, err, "should be equal")
-	assert.Equal(t, []string{"d", "i", "n"}, cmds, "should be equal")
+	assert.Equal(t, []string{"d", "i"}, cmds, "should be equal")
+}
+
+func TestNormalizeFilterCmdsRejectNoop(t *testing.T) {
+	cmds, err := normalizeFilterCmds([]string{"n"})
+	assert.Nil(t, cmds, "should be equal")
+	assert.EqualError(t, err, `filter.cmds: unsupported op type "n"; noop oplogs are already filtered by the built-in NoopFilter`)
 }
 
 func TestCheckDefaultValueInvalidFilterCmds(t *testing.T) {
@@ -25,5 +31,5 @@ func TestCheckDefaultValueInvalidFilterCmds(t *testing.T) {
 	}
 
 	err := checkDefaultValue()
-	assert.EqualError(t, err, "filter.cmds[delete] should in {i, u, d, c, n}")
+	assert.EqualError(t, err, `filter.cmds: unknown op type "delete", must be one of {i, u, d, c}`)
 }

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -38,7 +38,7 @@ type Configuration struct {
 	KafkaProducerMaxMessage                int      `config:"tunnel.kafka.producer.max_message_bytes"` // add v2.8.7
 	TunnelJsonFormat                       string   `config:"tunnel.json.format"`
 	TunnelMongoSslRootCaFile               string   `config:"tunnel.mongo_ssl_root_ca_file"` // add v2.6.2
-	FilterCmds                             []string `config:"filter.cmds"`
+	FilterOpTypes                          []string `config:"filter.op_types"`
 	FilterNamespaceBlack                   []string `config:"filter.namespace.black"`
 	FilterNamespaceWhite                   []string `config:"filter.namespace.white"`
 	FilterPassSpecialDb                    []string `config:"filter.pass.special.db"`

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -38,6 +38,7 @@ type Configuration struct {
 	KafkaProducerMaxMessage                int      `config:"tunnel.kafka.producer.max_message_bytes"` // add v2.8.7
 	TunnelJsonFormat                       string   `config:"tunnel.json.format"`
 	TunnelMongoSslRootCaFile               string   `config:"tunnel.mongo_ssl_root_ca_file"` // add v2.6.2
+	FilterCmds                             []string `config:"filter.cmds"`
 	FilterNamespaceBlack                   []string `config:"filter.namespace.black"`
 	FilterNamespaceWhite                   []string `config:"filter.namespace.white"`
 	FilterPassSpecialDb                    []string `config:"filter.pass.special.db"`

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -543,7 +543,7 @@ func TestCmdFilter(t *testing.T) {
 		fmt.Printf("TestCmdFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{" d ", "I"})
+		filter := NewCmdFilter([]string{"d", "i"})
 
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -248,6 +248,68 @@ func TestNamespaceFilter(t *testing.T) {
 		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
 	}
 
+	{
+		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
+		nr++
+
+		filter := NewNamespaceFilter([]string{"zz.mmm"}, nil)
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key: "applyOps",
+						Value: []any{
+							bson.D{
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ns", Value: "zz.mmm"},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "a", Value: 1},
+									bson.E{Key: "_id", Value: "xxx"},
+								}},
+							},
+							bson.D{
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ns", Value: "zz.x"},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "xyz", Value: "ff"},
+									bson.E{Key: "_id", Value: "yyy"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
+		assert.Equal(t, "zz.mmm", oplog.GetKey(log.Object[0].Value.(bson.A)[0].(bson.D), "ns"), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestNamespaceFilter case %d.\n", nr)
+		nr++
+
+		filter := NewNamespaceFilter([]string{"zz.mmm"}, nil)
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key:   "applyOps",
+						Value: []any{"illegal"},
+					},
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			assert.Equal(t, false, filter.Filter(log), "should be equal")
+		}, "should be equal")
+		assert.Equal(t, []any{"illegal"}, log.Object[0].Value, "should be equal")
+	}
+
 	// applyOps with inner delete ops for 'config.system.sessions'
 	// NamespaceFilter will not handle it, it's handled by AutologousFilter
 	{
@@ -391,6 +453,52 @@ func TestNamespaceFilter(t *testing.T) {
 			},
 		}
 		assert.Equal(t, true, filter.Filter(log1), "should be equal")
+
+		log2 := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				TxnNumber: &txnN[0],
+				Object: bson.D{
+					bson.E{
+						Key: "applyOps",
+						Value: []any{
+							bson.D{
+								bson.E{Key: "ns", Value: "zl.y"},
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.M{
+									"_id": int64(4),
+									"x":   json.NumberLong(-20),
+									"y":   json.NumberLong(5)}},
+							},
+							bson.D{
+								bson.E{Key: "ns", Value: "zl.y"},
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ui", Value: primitive.Binary{
+									Subtype: 4,
+									Data:    []byte{0, 1, 3, 4, 5, 6, 7},
+								}},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: int64(5)},
+									bson.E{Key: "x", Value: json.NumberLong(-30)},
+									bson.E{Key: "y", Value: json.NumberLong(11)},
+								}},
+							},
+						},
+					},
+				},
+				Timestamp:   utils.TimeToTimestamp(time.Now().Unix()),
+				Term:        &term[0],
+				Version:     2,
+				PrevOpTime:  utils.MarshalData(bson.D{{"ts", utils.Int64ToTimestamp(0)}}),
+				MultiOpType: &multiOpType[1], // 1 for vectored insert oplog format
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log2), "should be equal")
 	}
 
 	// applyOps with inner delete ops for 'config.system.preimages'
@@ -597,6 +705,36 @@ func TestCmdFilter(t *testing.T) {
 		fmt.Printf("TestCmdFilter case %d.\n", nr)
 		nr++
 
+		filter := NewCmdFilter([]string{"i"})
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key: "applyOps",
+						Value: []any{
+							bson.D{
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ns", Value: "zz.mmm"},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: "generic-slice-doc"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+		assert.Equal(t, 0, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
 		filter := NewCmdFilter([]string{"d"})
 		log := newApplyOpsLog([]bson.D{
 			{
@@ -775,6 +913,28 @@ func TestCmdFilter(t *testing.T) {
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
 		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
 		assert.Equal(t, "d", oplog.GetKey(log.Object[0].Value.(bson.A)[0].(bson.D), "op"), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"i"})
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key:   "applyOps",
+						Value: []any{"illegal"},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, []any{"illegal"}, log.Object[0].Value, "should be equal")
 	}
 }
 

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -508,6 +508,21 @@ func TestCmdFilter(t *testing.T) {
 	// test CmdFilter
 
 	var nr int
+	newApplyOpsLog := func(ops []bson.D) *oplog.PartialLog {
+		return &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key:   "applyOps",
+						Value: ops,
+					},
+				},
+			},
+		}
+	}
+
 	{
 		fmt.Printf("TestCmdFilter case %d.\n", nr)
 		nr++
@@ -550,6 +565,216 @@ func TestCmdFilter(t *testing.T) {
 			},
 		}
 		assert.Equal(t, false, filter.Filter(log), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"d"})
+		log := newApplyOpsLog([]bson.D{
+			{
+				bson.E{Key: "op", Value: "d"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "xxx"},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "d"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "yyy"},
+				}},
+			},
+		})
+
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+		assert.Equal(t, 0, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"d"})
+		log := newApplyOpsLog([]bson.D{
+			{
+				bson.E{Key: "op", Value: "d"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "xxx"},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "i"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "zzz"},
+				}},
+			},
+		})
+
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
+		assert.Equal(t, "i", oplog.GetKey(log.Object[0].Value.(bson.A)[0].(bson.D), "op"), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"i"})
+		log := newApplyOpsLog([]bson.D{
+			{
+				bson.E{Key: "op", Value: "i"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "xxx"},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "i"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "zzz"},
+				}},
+			},
+		})
+
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+		assert.Equal(t, 0, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"i"})
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Namespace: "admin.$cmd",
+				Operation: "c",
+				Object: bson.D{
+					{
+						Key: "applyOps",
+						Value: primitive.A{
+							bson.D{
+								bson.E{Key: "op", Value: "i"},
+								bson.E{Key: "ns", Value: "zz.mmm"},
+								bson.E{Key: "o", Value: bson.D{
+									bson.E{Key: "_id", Value: "primitive-array-doc"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+		assert.Equal(t, 0, len(log.Object[0].Value.(bson.A)), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"c", "d"})
+		log := newApplyOpsLog([]bson.D{
+			{
+				bson.E{Key: "op", Value: "d"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "xxx"},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "i"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "zzz"},
+				}},
+			},
+		})
+
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+		assert.Equal(t, 2, len(log.Object[0].Value.([]bson.D)), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"u"})
+		log := newApplyOpsLog([]bson.D{
+			{
+				bson.E{Key: "op", Value: "i"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "insert-doc"},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "u"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o2", Value: bson.D{
+					bson.E{Key: "_id", Value: "update-doc"},
+				}},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "$set", Value: bson.D{{Key: "x", Value: 1}}},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "d"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "delete-doc"},
+				}},
+			},
+		})
+
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 2, len(log.Object[0].Value.(bson.A)), "should be equal")
+		assert.Equal(t, "i", oplog.GetKey(log.Object[0].Value.(bson.A)[0].(bson.D), "op"), "should be equal")
+		assert.Equal(t, "d", oplog.GetKey(log.Object[0].Value.(bson.A)[1].(bson.D), "op"), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{"i", "u"})
+		log := newApplyOpsLog([]bson.D{
+			{
+				bson.E{Key: "op", Value: "i"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "insert-doc"},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "u"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o2", Value: bson.D{
+					bson.E{Key: "_id", Value: "update-doc"},
+				}},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "$set", Value: bson.D{{Key: "x", Value: 1}}},
+				}},
+			},
+			{
+				bson.E{Key: "op", Value: "d"},
+				bson.E{Key: "ns", Value: "zz.mmm"},
+				bson.E{Key: "o", Value: bson.D{
+					bson.E{Key: "_id", Value: "delete-doc"},
+				}},
+			},
+		})
+
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+		assert.Equal(t, 1, len(log.Object[0].Value.(bson.A)), "should be equal")
+		assert.Equal(t, "d", oplog.GetKey(log.Object[0].Value.(bson.A)[0].(bson.D), "op"), "should be equal")
 	}
 }
 

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -504,6 +504,55 @@ func TestGidFilter(t *testing.T) {
 	}
 }
 
+func TestCmdFilter(t *testing.T) {
+	// test CmdFilter
+
+	var nr int
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter(nil)
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "d",
+			},
+		}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+
+		log = &oplog.PartialLog{}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+	}
+
+	{
+		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		nr++
+
+		filter := NewCmdFilter([]string{" d ", "I"})
+
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "d",
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+
+		log = &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "i",
+			},
+		}
+		assert.Equal(t, true, filter.Filter(log), "should be equal")
+
+		log = &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "u",
+			},
+		}
+		assert.Equal(t, false, filter.Filter(log), "should be equal")
+	}
+}
+
 func TestAutologousFilter(t *testing.T) {
 	// test AutologousFilter
 

--- a/collector/filter/filter_test.go
+++ b/collector/filter/filter_test.go
@@ -612,8 +612,8 @@ func TestGidFilter(t *testing.T) {
 	}
 }
 
-func TestCmdFilter(t *testing.T) {
-	// test CmdFilter
+func TestOpTypeFilter(t *testing.T) {
+	// test OpTypeFilter
 
 	var nr int
 	newApplyOpsLog := func(ops []bson.D) *oplog.PartialLog {
@@ -632,10 +632,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter(nil)
+		filter := NewOpTypeFilter(nil)
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
 				Operation: "d",
@@ -648,10 +648,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"d", "i"})
+		filter := NewOpTypeFilter([]string{"d", "i"})
 
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
@@ -676,10 +676,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"d"})
+		filter := NewOpTypeFilter([]string{"d"})
 		log := newApplyOpsLog([]bson.D{
 			{
 				bson.E{Key: "op", Value: "d"},
@@ -702,10 +702,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"i"})
+		filter := NewOpTypeFilter([]string{"i"})
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
 				Namespace: "admin.$cmd",
@@ -732,10 +732,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"d"})
+		filter := NewOpTypeFilter([]string{"d"})
 		log := newApplyOpsLog([]bson.D{
 			{
 				bson.E{Key: "op", Value: "d"},
@@ -759,10 +759,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"i"})
+		filter := NewOpTypeFilter([]string{"i"})
 		log := newApplyOpsLog([]bson.D{
 			{
 				bson.E{Key: "op", Value: "i"},
@@ -785,10 +785,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"i"})
+		filter := NewOpTypeFilter([]string{"i"})
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
 				Namespace: "admin.$cmd",
@@ -815,10 +815,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"c", "d"})
+		filter := NewOpTypeFilter([]string{"c", "d"})
 		log := newApplyOpsLog([]bson.D{
 			{
 				bson.E{Key: "op", Value: "d"},
@@ -841,10 +841,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"u"})
+		filter := NewOpTypeFilter([]string{"u"})
 		log := newApplyOpsLog([]bson.D{
 			{
 				bson.E{Key: "op", Value: "i"},
@@ -879,10 +879,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"i", "u"})
+		filter := NewOpTypeFilter([]string{"i", "u"})
 		log := newApplyOpsLog([]bson.D{
 			{
 				bson.E{Key: "op", Value: "i"},
@@ -916,10 +916,10 @@ func TestCmdFilter(t *testing.T) {
 	}
 
 	{
-		fmt.Printf("TestCmdFilter case %d.\n", nr)
+		fmt.Printf("TestOpTypeFilter case %d.\n", nr)
 		nr++
 
-		filter := NewCmdFilter([]string{"i"})
+		filter := NewOpTypeFilter([]string{"i"})
 		log := &oplog.PartialLog{
 			ParsedLog: oplog.ParsedLog{
 				Namespace: "admin.$cmd",

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/alibaba/MongoShake/v2/oplog"
 	LOG "github.com/alibaba/MongoShake/v2/third_party/log4go"
@@ -104,8 +103,9 @@ func (filter *CmdFilter) hasApplyOpsDMLFilter() bool {
 // filterApplyOpsDML removes matching DML ops inside applyOps and returns the
 // remaining inner ops.
 func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, int, bool) {
-	ops, ok := extractApplyOps(logObject)
-	if !ok {
+	ops, err := oplog.NormalizeApplyOps(logObject)
+	if err != nil {
+		_ = LOG.Error("normalize applyOps failed: %v. log:%+v", err, logObject)
 		return nil, 0, false
 	}
 
@@ -140,42 +140,6 @@ func (filter *CmdFilter) shouldFilterApplyOpsInnerOp(operation string) bool {
 	default:
 		return false
 	}
-}
-
-// extractApplyOps extracts applyOps inner operations from the supported BSON
-// representations already used in the project.
-func extractApplyOps(logObject bson.D) ([]bson.D, bool) {
-	var ops []bson.D
-
-	switch v := oplog.GetKey(logObject, "applyOps").(type) {
-	case []bson.D:
-		ops = v
-	case []any:
-		ops = make([]bson.D, 0, len(v))
-		for _, ele := range v {
-			doc, ok := ele.(bson.D)
-			if !ok {
-				LOG.Error("unknown applyOps element type, filter can't handle. log:%+v", logObject)
-				return nil, false
-			}
-			ops = append(ops, doc)
-		}
-	case primitive.A:
-		ops = make([]bson.D, 0, len(v))
-		for _, ele := range v {
-			doc, ok := ele.(bson.D)
-			if !ok {
-				LOG.Error("unknown applyOps element type, filter can't handle. log:%+v", logObject)
-				return nil, false
-			}
-			ops = append(ops, doc)
-		}
-	default:
-		LOG.Error("unknown applyOps type, filter can't handle. log:%+v", logObject)
-		return nil, false
-	}
-
-	return ops, true
 }
 
 type GidFilter struct {
@@ -382,28 +346,16 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 		case "applyOps":
 			// parse and reorganize all inner ops within the transaction,
 			// also handle vectored insert oplog format with {multiOpType:1} introduced in 8.0
-			var ops []bson.D
+			ops, err := oplog.NormalizeApplyOps(log.Object)
+			if err != nil {
+				_ = LOG.Error("normalize applyOps failed: %v. log:%+v", err, log.Object)
+				return false
+			}
 			var remainOps bson.A
 
 			isVectoredInsert := false
 			if log.MultiOpType != nil && *log.MultiOpType == 1 {
 				isVectoredInsert = true
-			}
-			// it's very strange, some documents are []interface, some are []bson.D
-			switch v := oplog.GetKey(log.Object, "applyOps").(type) {
-			case []interface{}:
-				for _, ele := range v {
-					ops = append(ops, ele.(bson.D))
-				}
-			case []bson.D:
-				ops = v
-			case primitive.A:
-				for _, ele := range v {
-					ops = append(ops, ele.(bson.D))
-				}
-			default:
-				LOG.Error("unknown applyOps type, filter can't handle. log:%+v", log.Object)
-				return false
 			}
 			for _, ele := range ops {
 				innerNs := oplog.GetKey(ele, "ns").(string)

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -53,8 +53,127 @@ func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
 	}
 
 	operation := strings.TrimSpace(strings.ToLower(log.Operation))
-	_, ok := filter.cmdMp[operation]
-	return ok
+	// Command oplogs require a dedicated path:
+	//
+	//  1. Non-`c` operations keep the original behavior and are filtered only by
+	//     their top-level `op`.
+	//  2. If the current oplog is `c` and `filter.cmds=c` is configured, keep
+	//     filtering the whole command oplog by its top-level `op`.
+	//  3. Only when `c` is not configured, but one of `i/u/d` is configured and
+	//     the command is `applyOps`, do we rewrite matching inner DML ops. This
+	//     keeps top-level `c` filtering higher priority than partial `applyOps`
+	//     rewriting.
+	_, topLevelMatched := filter.cmdMp[operation]
+	if operation != "c" || topLevelMatched {
+		return topLevelMatched
+	}
+
+	if !filter.hasApplyOpsDMLFilter() {
+		return false
+	}
+
+	command, found := oplog.ExtraCommandName(log.Object)
+	if !found || command != "applyOps" {
+		return false
+	}
+
+	remainOps, ok := filter.filterApplyOpsDML(log.Object)
+	if !ok {
+		return false
+	}
+
+	oplog.SetFiled(log.Object, "applyOps", remainOps)
+	LOG.Info("CmdFilter applyOps DML filter?[%v], after reorganize: %v",
+		len(remainOps) == 0, log.Object)
+	return len(remainOps) == 0
+}
+
+// hasApplyOpsDMLFilter reports whether inner applyOps rewriting is relevant for
+// the current filter configuration.
+func (filter *CmdFilter) hasApplyOpsDMLFilter() bool {
+	for _, op := range []string{"i", "u", "d"} {
+		if _, ok := filter.cmdMp[op]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filterApplyOpsDML removes matching DML ops inside applyOps and returns the
+// remaining inner ops.
+func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, bool) {
+	ops, ok := extractApplyOps(logObject)
+	if !ok {
+		return nil, false
+	}
+
+	remainOps := make(bson.A, 0, len(ops))
+	for _, ele := range ops {
+		innerOperation, ok := oplog.GetKey(ele, "op").(string)
+		if !ok {
+			LOG.Warn("CmdFilter meets illegal applyOps inner op: %v", ele)
+			return nil, false
+		}
+
+		innerOperation = strings.TrimSpace(strings.ToLower(innerOperation))
+		if filter.shouldFilterApplyOpsInnerOp(innerOperation) {
+			LOG.Info("CmdFilter filter inner %s op in applyOps: %v", innerOperation, ele)
+			continue
+		}
+
+		remainOps = append(remainOps, ele)
+	}
+
+	return remainOps, true
+}
+
+// shouldFilterApplyOpsInnerOp reports whether the given inner applyOps op
+// should be filtered by the current DML filter configuration.
+func (filter *CmdFilter) shouldFilterApplyOpsInnerOp(operation string) bool {
+	switch operation {
+	case "i", "u", "d":
+		_, ok := filter.cmdMp[operation]
+		return ok
+	default:
+		return false
+	}
+}
+
+// extractApplyOps extracts applyOps inner operations from the supported BSON
+// representations already used in the project.
+func extractApplyOps(logObject bson.D) ([]bson.D, bool) {
+	var ops []bson.D
+
+	switch v := oplog.GetKey(logObject, "applyOps").(type) {
+	case []bson.D:
+		ops = v
+	case []any:
+		ops = make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			doc, ok := ele.(bson.D)
+			if !ok {
+				LOG.Error("unknown applyOps element type, filter can't handle. log:%+v", logObject)
+				return nil, false
+			}
+			ops = append(ops, doc)
+		}
+	case primitive.A:
+		ops = make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			doc, ok := ele.(bson.D)
+			if !ok {
+				LOG.Error("unknown applyOps element type, filter can't handle. log:%+v", logObject)
+				return nil, false
+			}
+			ops = append(ops, doc)
+		}
+	default:
+		LOG.Error("unknown applyOps type, filter can't handle. log:%+v", logObject)
+		return nil, false
+	}
+
+	return ops, true
 }
 
 type GidFilter struct {
@@ -101,7 +220,7 @@ func (filter *AutologousFilter) Filter(log *oplog.PartialLog) bool {
 	if log.Namespace == "admin.$cmd" && operation == "applyOps" {
 		ns, err := oplog.ExtractInnerNs(&log.ParsedLog)
 		if err != nil {
-			_ = LOG.Warn("ExtractInnerNs meets error:%v", err)
+			LOG.Warn("ExtractInnerNs meets error:%v", err)
 			return false
 		}
 		if ns == "config.system.sessions" || ns == "config.system.preimages" {
@@ -210,7 +329,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 		// DDL
 		operation, found := oplog.ExtraCommandName(log.Object)
 		if !found {
-			_ = LOG.Warn("extraCommandName meets type[%s] which is not implemented, ignore!", operation)
+			LOG.Warn("extraCommandName meets type[%s] which is not implemented, ignore!", operation)
 			return false
 		}
 
@@ -244,7 +363,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 		case "emptycapped":
 			col, ok := oplog.GetKey(log.Object, operation).(string)
 			if !ok {
-				_ = LOG.Warn("extraCommandName meets illegal %v oplog %v, ignore!", operation, log.Object)
+				LOG.Warn("extraCommandName meets illegal %v oplog %v, ignore!", operation, log.Object)
 				return false
 			}
 			log.Namespace = fmt.Sprintf("%s.%s", db, col)
@@ -253,7 +372,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 			// { "renameCollection" : "my.tbl", "to" : "my.my", "stayTemp" : false, "dropTarget" : false }
 			ns, ok := oplog.GetKey(log.Object, operation).(string)
 			if !ok {
-				_ = LOG.Warn("extraCommandName meets illegal %v oplog %v, ignore!", operation, log.Object)
+				LOG.Warn("extraCommandName meets illegal %v oplog %v, ignore!", operation, log.Object)
 				return false
 			}
 			log.Namespace = ns
@@ -281,7 +400,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 					ops = append(ops, ele.(bson.D))
 				}
 			default:
-				_ = LOG.Error("unknown applyOps type, filter can't handle. log:%+v", log.Object)
+				LOG.Error("unknown applyOps type, filter can't handle. log:%+v", log.Object)
 				return false
 			}
 			for _, ele := range ops {

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -29,6 +29,34 @@ func (chain OplogFilterChain) IterateFilter(log *oplog.PartialLog) bool {
 	return false
 }
 
+type CmdFilter struct {
+	cmdMp map[string]struct{}
+}
+
+func NewCmdFilter(cmds []string) *CmdFilter {
+	mp := make(map[string]struct{}, len(cmds))
+	for _, cmd := range cmds {
+		cmd = strings.TrimSpace(strings.ToLower(cmd))
+		if cmd == "" {
+			continue
+		}
+		mp[cmd] = struct{}{}
+	}
+	return &CmdFilter{
+		cmdMp: mp,
+	}
+}
+
+func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
+	if len(filter.cmdMp) == 0 {
+		return false
+	}
+
+	operation := strings.TrimSpace(strings.ToLower(log.Operation))
+	_, ok := filter.cmdMp[operation]
+	return ok
+}
+
 type GidFilter struct {
 	gidMp map[string]struct{}
 }

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -29,14 +29,15 @@ func (chain OplogFilterChain) IterateFilter(log *oplog.PartialLog) bool {
 	return false
 }
 
+// CmdFilter filters oplogs by oplog op type instead of only command oplogs.
 type CmdFilter struct {
 	cmdMp map[string]struct{}
 }
 
+// NewCmdFilter trusts sanitize to provide normalized op type values.
 func NewCmdFilter(cmds []string) *CmdFilter {
 	mp := make(map[string]struct{}, len(cmds))
 	for _, cmd := range cmds {
-		cmd = strings.TrimSpace(strings.ToLower(cmd))
 		if cmd == "" {
 			continue
 		}
@@ -52,7 +53,7 @@ func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
 		return false
 	}
 
-	operation := strings.TrimSpace(strings.ToLower(log.Operation))
+	operation := log.Operation
 	// Command oplogs require a dedicated path:
 	//
 	//  1. Non-`c` operations keep the original behavior and are filtered only by
@@ -77,14 +78,14 @@ func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
 		return false
 	}
 
-	remainOps, ok := filter.filterApplyOpsDML(log.Object)
+	remainOps, filteredCount, ok := filter.filterApplyOpsDML(log.Object)
 	if !ok {
 		return false
 	}
 
 	oplog.SetFiled(log.Object, "applyOps", remainOps)
-	LOG.Info("CmdFilter applyOps DML filter?[%v], after reorganize: %v",
-		len(remainOps) == 0, log.Object)
+	LOG.Info("CmdFilter filtered %d inner applyOps ops, drop oplog?[%v], after reorganize: %v",
+		filteredCount, len(remainOps) == 0, log.Object)
 	return len(remainOps) == 0
 }
 
@@ -102,30 +103,31 @@ func (filter *CmdFilter) hasApplyOpsDMLFilter() bool {
 
 // filterApplyOpsDML removes matching DML ops inside applyOps and returns the
 // remaining inner ops.
-func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, bool) {
+func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, int, bool) {
 	ops, ok := extractApplyOps(logObject)
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
 
 	remainOps := make(bson.A, 0, len(ops))
+	filteredCount := 0
 	for _, ele := range ops {
 		innerOperation, ok := oplog.GetKey(ele, "op").(string)
 		if !ok {
 			LOG.Warn("CmdFilter meets illegal applyOps inner op: %v", ele)
-			return nil, false
+			return nil, 0, false
 		}
 
-		innerOperation = strings.TrimSpace(strings.ToLower(innerOperation))
 		if filter.shouldFilterApplyOpsInnerOp(innerOperation) {
-			LOG.Info("CmdFilter filter inner %s op in applyOps: %v", innerOperation, ele)
+			LOG.Debug("CmdFilter filter inner %s op in applyOps: %v", innerOperation, ele)
+			filteredCount++
 			continue
 		}
 
 		remainOps = append(remainOps, ele)
 	}
 
-	return remainOps, true
+	return remainOps, filteredCount, true
 }
 
 // shouldFilterApplyOpsInnerOp reports whether the given inner applyOps op

--- a/collector/filter/oplog_filter.go
+++ b/collector/filter/oplog_filter.go
@@ -28,27 +28,27 @@ func (chain OplogFilterChain) IterateFilter(log *oplog.PartialLog) bool {
 	return false
 }
 
-// CmdFilter filters oplogs by oplog op type instead of only command oplogs.
-type CmdFilter struct {
-	cmdMp map[string]struct{}
+// OpTypeFilter filters oplogs by oplog op type instead of only command oplogs.
+type OpTypeFilter struct {
+	opTypeMp map[string]struct{}
 }
 
-// NewCmdFilter trusts sanitize to provide normalized op type values.
-func NewCmdFilter(cmds []string) *CmdFilter {
-	mp := make(map[string]struct{}, len(cmds))
-	for _, cmd := range cmds {
-		if cmd == "" {
+// NewOpTypeFilter trusts sanitize to provide normalized op type values.
+func NewOpTypeFilter(opTypes []string) *OpTypeFilter {
+	mp := make(map[string]struct{}, len(opTypes))
+	for _, opType := range opTypes {
+		if opType == "" {
 			continue
 		}
-		mp[cmd] = struct{}{}
+		mp[opType] = struct{}{}
 	}
-	return &CmdFilter{
-		cmdMp: mp,
+	return &OpTypeFilter{
+		opTypeMp: mp,
 	}
 }
 
-func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
-	if len(filter.cmdMp) == 0 {
+func (filter *OpTypeFilter) Filter(log *oplog.PartialLog) bool {
+	if len(filter.opTypeMp) == 0 {
 		return false
 	}
 
@@ -57,13 +57,13 @@ func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
 	//
 	//  1. Non-`c` operations keep the original behavior and are filtered only by
 	//     their top-level `op`.
-	//  2. If the current oplog is `c` and `filter.cmds=c` is configured, keep
+	//  2. If the current oplog is `c` and `filter.op_types=c` is configured, keep
 	//     filtering the whole command oplog by its top-level `op`.
 	//  3. Only when `c` is not configured, but one of `i/u/d` is configured and
 	//     the command is `applyOps`, do we rewrite matching inner DML ops. This
 	//     keeps top-level `c` filtering higher priority than partial `applyOps`
 	//     rewriting.
-	_, topLevelMatched := filter.cmdMp[operation]
+	_, topLevelMatched := filter.opTypeMp[operation]
 	if operation != "c" || topLevelMatched {
 		return topLevelMatched
 	}
@@ -83,16 +83,16 @@ func (filter *CmdFilter) Filter(log *oplog.PartialLog) bool {
 	}
 
 	oplog.SetFiled(log.Object, "applyOps", remainOps)
-	LOG.Info("CmdFilter filtered %d inner applyOps ops, drop oplog?[%v], after reorganize: %v",
+	LOG.Info("OpTypeFilter filtered %d inner applyOps ops, drop oplog?[%v], after reorganize: %v",
 		filteredCount, len(remainOps) == 0, log.Object)
 	return len(remainOps) == 0
 }
 
 // hasApplyOpsDMLFilter reports whether inner applyOps rewriting is relevant for
 // the current filter configuration.
-func (filter *CmdFilter) hasApplyOpsDMLFilter() bool {
+func (filter *OpTypeFilter) hasApplyOpsDMLFilter() bool {
 	for _, op := range []string{"i", "u", "d"} {
-		if _, ok := filter.cmdMp[op]; ok {
+		if _, ok := filter.opTypeMp[op]; ok {
 			return true
 		}
 	}
@@ -102,7 +102,7 @@ func (filter *CmdFilter) hasApplyOpsDMLFilter() bool {
 
 // filterApplyOpsDML removes matching DML ops inside applyOps and returns the
 // remaining inner ops.
-func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, int, bool) {
+func (filter *OpTypeFilter) filterApplyOpsDML(logObject bson.D) (bson.A, int, bool) {
 	ops, err := oplog.NormalizeApplyOps(logObject)
 	if err != nil {
 		_ = LOG.Error("normalize applyOps failed: %v. log:%+v", err, logObject)
@@ -114,12 +114,12 @@ func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, int, bool)
 	for _, ele := range ops {
 		innerOperation, ok := oplog.GetKey(ele, "op").(string)
 		if !ok {
-			LOG.Warn("CmdFilter meets illegal applyOps inner op: %v", ele)
+			_ = LOG.Warn("OpTypeFilter meets illegal applyOps inner op: %v", ele)
 			return nil, 0, false
 		}
 
 		if filter.shouldFilterApplyOpsInnerOp(innerOperation) {
-			LOG.Debug("CmdFilter filter inner %s op in applyOps: %v", innerOperation, ele)
+			LOG.Debug("OpTypeFilter filter inner %s op in applyOps: %v", innerOperation, ele)
 			filteredCount++
 			continue
 		}
@@ -132,10 +132,10 @@ func (filter *CmdFilter) filterApplyOpsDML(logObject bson.D) (bson.A, int, bool)
 
 // shouldFilterApplyOpsInnerOp reports whether the given inner applyOps op
 // should be filtered by the current DML filter configuration.
-func (filter *CmdFilter) shouldFilterApplyOpsInnerOp(operation string) bool {
+func (filter *OpTypeFilter) shouldFilterApplyOpsInnerOp(operation string) bool {
 	switch operation {
 	case "i", "u", "d":
-		_, ok := filter.cmdMp[operation]
+		_, ok := filter.opTypeMp[operation]
 		return ok
 	default:
 		return false
@@ -186,7 +186,7 @@ func (filter *AutologousFilter) Filter(log *oplog.PartialLog) bool {
 	if log.Namespace == "admin.$cmd" && operation == "applyOps" {
 		ns, err := oplog.ExtractInnerNs(&log.ParsedLog)
 		if err != nil {
-			LOG.Warn("ExtractInnerNs meets error:%v", err)
+			_ = LOG.Warn("ExtractInnerNs meets error:%v", err)
 			return false
 		}
 		if ns == "config.system.sessions" || ns == "config.system.preimages" {
@@ -295,7 +295,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 		// DDL
 		operation, found := oplog.ExtraCommandName(log.Object)
 		if !found {
-			LOG.Warn("extraCommandName meets type[%s] which is not implemented, ignore!", operation)
+			_ = LOG.Warn("extraCommandName meets type[%s] which is not implemented, ignore!", operation)
 			return false
 		}
 
@@ -338,7 +338,7 @@ func (filter *NamespaceFilter) Filter(log *oplog.PartialLog) bool {
 			// { "renameCollection" : "my.tbl", "to" : "my.my", "stayTemp" : false, "dropTarget" : false }
 			ns, ok := oplog.GetKey(log.Object, operation).(string)
 			if !ok {
-				LOG.Warn("extraCommandName meets illegal %v oplog %v, ignore!", operation, log.Object)
+				_ = LOG.Warn("extraCommandName meets illegal %v oplog %v, ignore!", operation, log.Object)
 				return false
 			}
 			log.Namespace = ns

--- a/collector/syncer.go
+++ b/collector/syncer.go
@@ -134,7 +134,7 @@ func NewOplogSyncer(
 	filterList := filter.OplogFilterChain{
 		new(filter.AutologousFilter),
 		new(filter.NoopFilter),
-		filter.NewCmdFilter(conf.Options.FilterCmds),
+		filter.NewOpTypeFilter(conf.Options.FilterOpTypes),
 		filter.NewGidFilter(gids),
 	}
 

--- a/collector/syncer.go
+++ b/collector/syncer.go
@@ -131,7 +131,12 @@ func NewOplogSyncer(
 		syncer.hasher = oplog.NewWhiteListObjectIdHasher(conf.Options.IncrSyncShardByObjectIdWhiteList)
 	}
 
-	filterList := filter.OplogFilterChain{new(filter.AutologousFilter), new(filter.NoopFilter), filter.NewGidFilter(gids)}
+	filterList := filter.OplogFilterChain{
+		new(filter.AutologousFilter),
+		new(filter.NoopFilter),
+		filter.NewCmdFilter(conf.Options.FilterCmds),
+		filter.NewGidFilter(gids),
+	}
 
 	// namespace filter, heavy operation
 	if len(conf.Options.FilterNamespaceWhite) != 0 || len(conf.Options.FilterNamespaceBlack) != 0 {

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -163,7 +163,7 @@ filter.namespace.white =
 # 对于 "i"、"u"、"d"，会同时过滤顶层 oplog 和 applyOps 内层命中的 DML 操作；
 # 例如配置为 d 可过滤增量同步中的 delete oplog（如 TTL 删除、batched delete）；
 # 配置为 i;u 时，也会过滤 applyOps 内层命中的 insert/update。
-filter.cmds =
+filter.op_types =
 
 # some databases like "admin", "local", "mongoshake", "config" are
 # filtered, users can enable these database based on some special needs.

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -152,14 +152,14 @@ mongo_connect_mode = secondaryPreferred
 # 不能同时指定。分号分割不同namespace，每个namespace可以是db，也可以是db.collection。
 filter.namespace.black =
 filter.namespace.white =
-# filter oplog by op type. different ops are split by semicolon(;).
-# common values are "i", "u", "d", "c". keep empty to pass all oplogs.
-# noop oplog("n") is still filtered by the built-in NoopFilter by default.
+# filter oplog by oplog op type. different ops are split by semicolon(;).
+# valid values are "i", "u", "d", "c". keep empty to pass all oplogs.
+# this setting matches oplog op types instead of only MongoDB command oplogs.
 # for "i", "u", and "d", matching inner ops inside applyOps are also filtered.
 # e.g. set "d" to drop delete oplogs such as TTL delete or batched delete from incremental sync.
 # e.g. set "i;u" to drop matching insert/update ops even when they are nested inside applyOps.
-# 按 oplog op 类型过滤。多个 op 以分号(;)分隔。常用值包括 "i"、"u"、"d"、"c"。
-# noop oplog("n") 仍由内置 NoopFilter 默认过滤。保持为空表示不过滤；
+# 按 oplog op 类型过滤。多个 op 以分号(;)分隔。合法值包括 "i"、"u"、"d"、"c"。
+# 该配置匹配的是 oplog op 类型，不是只匹配 MongoDB command oplog。保持为空表示不过滤；
 # 对于 "i"、"u"、"d"，会同时过滤顶层 oplog 和 applyOps 内层命中的 DML 操作；
 # 例如配置为 d 可过滤增量同步中的 delete oplog（如 TTL 删除、batched delete）；
 # 配置为 i;u 时，也会过滤 applyOps 内层命中的 insert/update。

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -152,13 +152,17 @@ mongo_connect_mode = secondaryPreferred
 # 不能同时指定。分号分割不同namespace，每个namespace可以是db，也可以是db.collection。
 filter.namespace.black =
 filter.namespace.white =
-# filter oplog by top-level op type. different ops are split by semicolon(;).
+# filter oplog by op type. different ops are split by semicolon(;).
 # common values are "i", "u", "d", "c". keep empty to pass all oplogs.
 # noop oplog("n") is still filtered by the built-in NoopFilter by default.
-# e.g. set "d" to drop delete oplogs such as TTL delete from incremental sync.
-# 按 oplog 顶层 op 类型过滤。多个 op 以分号(;)分隔。常用值包括 "i"、"u"、"d"、"c"。
+# for "i", "u", and "d", matching inner ops inside applyOps are also filtered.
+# e.g. set "d" to drop delete oplogs such as TTL delete or batched delete from incremental sync.
+# e.g. set "i;u" to drop matching insert/update ops even when they are nested inside applyOps.
+# 按 oplog op 类型过滤。多个 op 以分号(;)分隔。常用值包括 "i"、"u"、"d"、"c"。
 # noop oplog("n") 仍由内置 NoopFilter 默认过滤。保持为空表示不过滤；
-# 例如配置为 d 可过滤增量同步中的 delete oplog（如 TTL 删除）。
+# 对于 "i"、"u"、"d"，会同时过滤顶层 oplog 和 applyOps 内层命中的 DML 操作；
+# 例如配置为 d 可过滤增量同步中的 delete oplog（如 TTL 删除、batched delete）；
+# 配置为 i;u 时，也会过滤 applyOps 内层命中的 insert/update。
 filter.cmds =
 
 # some databases like "admin", "local", "mongoshake", "config" are

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -152,6 +152,14 @@ mongo_connect_mode = secondaryPreferred
 # 不能同时指定。分号分割不同namespace，每个namespace可以是db，也可以是db.collection。
 filter.namespace.black =
 filter.namespace.white =
+# filter oplog by top-level op type. different ops are split by semicolon(;).
+# common values are "i", "u", "d", "c". keep empty to pass all oplogs.
+# noop oplog("n") is still filtered by the built-in NoopFilter by default.
+# e.g. set "d" to drop delete oplogs such as TTL delete from incremental sync.
+# 按 oplog 顶层 op 类型过滤。多个 op 以分号(;)分隔。常用值包括 "i"、"u"、"d"、"c"。
+# noop oplog("n") 仍由内置 NoopFilter 默认过滤。保持为空表示不过滤；
+# 例如配置为 d 可过滤增量同步中的 delete oplog（如 TTL 删除）。
+filter.cmds =
 
 # some databases like "admin", "local", "mongoshake", "config" are
 # filtered, users can enable these database based on some special needs.

--- a/executor/db_writer.go
+++ b/executor/db_writer.go
@@ -184,35 +184,21 @@ func RunCommand(database, operation string, log *oplog.PartialLog, client *mongo
 		 * Strictly speaking, we should handle applyOps nested case, but it is
 		 * complicate to fulfill, so we just use "applyOps" to run the command directly.
 		 */
+		ops, err := oplog.NormalizeApplyOps(log.Object)
+		if err != nil {
+			return err
+		}
+
 		var store bson.D
 		for _, ele := range log.Object {
 			if utils.ApplyOpsFilter(ele.Key) {
 				continue
 			}
 			if ele.Key == "applyOps" {
-				switch v := ele.Value.(type) {
-				case []interface{}:
-					for i, ele := range v {
-						doc := ele.(bson.D)
-						v[i] = oplog.RemoveFiled(doc, uuidMark)
-					}
-				case bson.D:
-					ret := make(bson.D, 0, len(v))
-					for _, ele := range v {
-						if ele.Key == uuidMark {
-							continue
-						}
-						ret = append(ret, ele)
-					}
-					ele.Value = ret
-				case []bson.M:
-					for _, ele := range v {
-						if _, ok := ele[uuidMark]; ok {
-							delete(ele, uuidMark)
-						}
-					}
+				for i, doc := range ops {
+					ops[i] = oplog.RemoveFiled(doc, uuidMark)
 				}
-
+				ele.Value = ops
 			}
 			store = append(store, ele)
 		}

--- a/executor/db_writer_test.go
+++ b/executor/db_writer_test.go
@@ -1562,6 +1562,119 @@ func TestRunCommand(t *testing.T) {
 		assert.Equal(t, int32(1), result[2]["x"], "should be equal")
 	}
 
+	// applyOps with []bson.D
+	{
+		fmt.Printf("TestRunCommand case %d.\n", nr)
+		nr++
+
+		conn, err := utils.NewMongoCommunityConn(testMongoAddress, "primary", true,
+			utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, "")
+		assert.Equal(t, nil, err, "should be equal")
+
+		err = conn.Client.Database("zz").Drop(nil)
+		assert.Equal(t, nil, err, "should be equal")
+
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					bson.E{
+						Key: "applyOps",
+						Value: []bson.D{
+							{
+								{Key: "ns", Value: "zz.y"},
+								{Key: "op", Value: "i"},
+								{Key: "ui", Value: "xxxx"},
+								{Key: "o", Value: bson.D{
+									{Key: "_id", Value: "bson-d-1"},
+									{Key: "hello", Value: "world"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		err = RunCommand(testDb, "applyOps", log, conn.Client)
+		assert.Equal(t, nil, err, "should be equal")
+
+		opts := options.Find().SetSort(bson.D{{"_id", 1}})
+		result, err := unit_test_common.FetchAllDocumentBsonM(conn.Client, "zz", "y", opts)
+		assert.Equal(t, nil, err, "should be equal")
+		assert.Equal(t, "bson-d-1", result[0]["_id"].(string), "should be equal")
+		assert.Equal(t, "world", result[0]["hello"].(string), "should be equal")
+	}
+
+	// applyOps with bson.A
+	{
+		fmt.Printf("TestRunCommand case %d.\n", nr)
+		nr++
+
+		conn, err := utils.NewMongoCommunityConn(testMongoAddress, "primary", true,
+			utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, "")
+		assert.Equal(t, nil, err, "should be equal")
+
+		err = conn.Client.Database("zz").Drop(nil)
+		assert.Equal(t, nil, err, "should be equal")
+
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					bson.E{
+						Key: "applyOps",
+						Value: bson.A{
+							bson.D{
+								{Key: "ns", Value: "zz.y"},
+								{Key: "op", Value: "i"},
+								{Key: "ui", Value: "xxxx"},
+								{Key: "o", Value: bson.D{
+									{Key: "_id", Value: "bson-a-1"},
+									{Key: "hello", Value: "world-a"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		err = RunCommand(testDb, "applyOps", log, conn.Client)
+		assert.Equal(t, nil, err, "should be equal")
+
+		opts := options.Find().SetSort(bson.D{{"_id", 1}})
+		result, err := unit_test_common.FetchAllDocumentBsonM(conn.Client, "zz", "y", opts)
+		assert.Equal(t, nil, err, "should be equal")
+		assert.Equal(t, "bson-a-1", result[0]["_id"].(string), "should be equal")
+		assert.Equal(t, "world-a", result[0]["hello"].(string), "should be equal")
+	}
+
+	// applyOps with illegal type
+	{
+		fmt.Printf("TestRunCommand case %d.\n", nr)
+		nr++
+
+		conn, err := utils.NewMongoCommunityConn(testMongoAddress, "primary", true,
+			utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, "")
+		assert.Equal(t, nil, err, "should be equal")
+
+		log := &oplog.PartialLog{
+			ParsedLog: oplog.ParsedLog{
+				Operation: "c",
+				Namespace: "admin.$cmd",
+				Object: bson.D{
+					bson.E{
+						Key:   "applyOps",
+						Value: 1,
+					},
+				},
+			},
+		}
+		err = RunCommand(testDb, "applyOps", log, conn.Client)
+		assert.EqualError(t, err, "applyOps field has unsupported type int")
+	}
+
 	// applyOps with {multiOpType:1} which should not be treated as txn.
 	{
 		fmt.Printf("TestRunCommand case %d.\n", nr)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -10,7 +10,6 @@ import (
 
 	nimo "github.com/gugemichael/nimo4go"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/transform"
@@ -277,38 +276,6 @@ func transformLogs(logs []*OplogRecord, nsTrans *transform.NamespaceTransform, t
 	return logs
 }
 
-// extractApplyOpsForTransform normalizes applyOps into []bson.D so namespace
-// transformation can handle logs rewritten by filters as well as raw decoded
-// BSON arrays.
-func extractApplyOpsForTransform(logObject bson.D) ([]bson.D, bool) {
-	switch v := oplog.GetKey(logObject, "applyOps").(type) {
-	case []bson.D:
-		return v, true
-	case []any:
-		ops := make([]bson.D, 0, len(v))
-		for _, ele := range v {
-			doc, ok := ele.(bson.D)
-			if !ok {
-				return nil, false
-			}
-			ops = append(ops, doc)
-		}
-		return ops, true
-	case primitive.A:
-		ops := make([]bson.D, 0, len(v))
-		for _, ele := range v {
-			doc, ok := ele.(bson.D)
-			if !ok {
-				return nil, false
-			}
-			ops = append(ops, doc)
-		}
-		return ops, true
-	default:
-		return nil, false
-	}
-}
-
 func transformPartialLog(partialLog *oplog.PartialLog, nsTrans *transform.NamespaceTransform, transformRef bool) *oplog.PartialLog {
 	db := strings.SplitN(partialLog.Namespace, ".", 2)[0]
 	if partialLog.Operation != "c" {
@@ -380,9 +347,9 @@ func transformPartialLog(partialLog *oplog.PartialLog, nsTrans *transform.Namesp
 			oplog.SetFiled(partialLog.Object, operation, partialLog.Namespace)
 			oplog.SetFiled(partialLog.Object, "to", nsTrans.Transform(toNs))
 		case "applyOps":
-			ops, ok := extractApplyOpsForTransform(partialLog.Object)
-			if !ok {
-				_ = LOG.Warn("transformPartialLog meets unsupported applyOps type, ignore! oplog=%v", partialLog.Object)
+			ops, err := oplog.NormalizeApplyOps(partialLog.Object)
+			if err != nil {
+				_ = LOG.Warn("transformPartialLog meets unsupported applyOps type[%v], ignore! oplog=%v", err, partialLog.Object)
 				return nil
 			}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -10,6 +10,7 @@ import (
 
 	nimo "github.com/gugemichael/nimo4go"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/transform"
@@ -276,6 +277,38 @@ func transformLogs(logs []*OplogRecord, nsTrans *transform.NamespaceTransform, t
 	return logs
 }
 
+// extractApplyOpsForTransform normalizes applyOps into []bson.D so namespace
+// transformation can handle logs rewritten by filters as well as raw decoded
+// BSON arrays.
+func extractApplyOpsForTransform(logObject bson.D) ([]bson.D, bool) {
+	switch v := oplog.GetKey(logObject, "applyOps").(type) {
+	case []bson.D:
+		return v, true
+	case []any:
+		ops := make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			doc, ok := ele.(bson.D)
+			if !ok {
+				return nil, false
+			}
+			ops = append(ops, doc)
+		}
+		return ops, true
+	case primitive.A:
+		ops := make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			doc, ok := ele.(bson.D)
+			if !ok {
+				return nil, false
+			}
+			ops = append(ops, doc)
+		}
+		return ops, true
+	default:
+		return nil, false
+	}
+}
+
 func transformPartialLog(partialLog *oplog.PartialLog, nsTrans *transform.NamespaceTransform, transformRef bool) *oplog.PartialLog {
 	db := strings.SplitN(partialLog.Namespace, ".", 2)[0]
 	if partialLog.Operation != "c" {
@@ -347,23 +380,28 @@ func transformPartialLog(partialLog *oplog.PartialLog, nsTrans *transform.Namesp
 			oplog.SetFiled(partialLog.Object, operation, partialLog.Namespace)
 			oplog.SetFiled(partialLog.Object, "to", nsTrans.Transform(toNs))
 		case "applyOps":
-			if ops := oplog.GetKey(partialLog.Object, "applyOps").([]bson.D); ops != nil {
-				// except field 'o'
-				except := map[string]struct{}{
-					"o": {},
-				}
-				for i, ele := range ops {
-					// m, keys := oplog.ConvertBsonD2M(ele)
-					m, keys := oplog.ConvertBsonD2MExcept(ele, except)
-					subLog := oplog.NewPartialLog(m)
-					transSubLog := transformPartialLog(subLog, nsTrans, transformRef)
-					if transSubLog == nil {
-						_ = LOG.Warn("transformPartialLog sub log %v return nil, ignore!", subLog)
-						return nil
-					}
-					ops[i] = transSubLog.Dump(keys, false)
-				}
+			ops, ok := extractApplyOpsForTransform(partialLog.Object)
+			if !ok {
+				_ = LOG.Warn("transformPartialLog meets unsupported applyOps type, ignore! oplog=%v", partialLog.Object)
+				return nil
 			}
+
+			// except field 'o'
+			except := map[string]struct{}{
+				"o": {},
+			}
+			for i, ele := range ops {
+				// m, keys := oplog.ConvertBsonD2M(ele)
+				m, keys := oplog.ConvertBsonD2MExcept(ele, except)
+				subLog := oplog.NewPartialLog(m)
+				transSubLog := transformPartialLog(subLog, nsTrans, transformRef)
+				if transSubLog == nil {
+					_ = LOG.Warn("transformPartialLog sub log %v return nil, ignore!", subLog)
+					return nil
+				}
+				ops[i] = transSubLog.Dump(keys, false)
+			}
+			oplog.SetFiled(partialLog.Object, "applyOps", ops)
 		default:
 			// such as: dropDatabase
 			partialLog.Namespace = nsTrans.Transform(partialLog.Namespace)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -537,6 +537,56 @@ func TestTransformLog(t *testing.T) {
 			},
 		}), logs[0], "should be equal")
 	}
+
+	{
+		fmt.Printf("TestTransformLog case %d.\n", nr)
+		nr++
+		nsTrans := transform.NewNamespaceTransform([]string{"fdb1:fdb2"})
+
+		logs := []*OplogRecord{
+			mockTransLogs("c", "admin.$cmd", bson.D{
+				primitive.E{
+					Key: "applyOps",
+					Value: []any{
+						bson.D{
+							primitive.E{"op", "i"},
+							primitive.E{"ns", "fdb1.fcol1"},
+							primitive.E{"o", bson.D{primitive.E{"a", 1}}},
+						},
+					},
+				},
+			}),
+		}
+
+		logs = transformLogs(logs, nsTrans, false)
+		assert.Equal(t, mockTransLogs("c", "admin.$cmd", bson.D{
+			primitive.E{
+				Key: "applyOps",
+				Value: []bson.D{
+					{
+						primitive.E{"op", "i"},
+						primitive.E{"ns", "fdb2.fcol1"},
+						primitive.E{"o", bson.D{primitive.E{"a", 1}}},
+					},
+				},
+			},
+		}), logs[0], "should be equal")
+	}
+
+	{
+		fmt.Printf("TestTransformLog case %d.\n", nr)
+		nr++
+		nsTrans := transform.NewNamespaceTransform([]string{"fdb1:fdb2"})
+		log := mockTransLogs("c", "admin.$cmd", bson.D{
+			primitive.E{
+				Key:   "applyOps",
+				Value: []any{"illegal"},
+			},
+		})
+
+		ret := transformPartialLog(log.original.partialLog, nsTrans, false)
+		assert.Nil(t, ret, "should be equal")
+	}
 }
 
 func TestCalculateTop3(t *testing.T) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -502,6 +502,41 @@ func TestTransformLog(t *testing.T) {
 			},
 		}), logs[0], "should be equal")
 	}
+
+	{
+		fmt.Printf("TestTransformLog case %d.\n", nr)
+		nr++
+		nsTrans := transform.NewNamespaceTransform([]string{"fdb1:fdb2"})
+
+		logs := []*OplogRecord{
+			mockTransLogs("c", "admin.$cmd", bson.D{
+				primitive.E{
+					Key: "applyOps",
+					Value: bson.A{
+						bson.D{
+							primitive.E{"op", "i"},
+							primitive.E{"ns", "fdb1.fcol1"},
+							primitive.E{"o", bson.D{primitive.E{"a", 1}}},
+						},
+					},
+				},
+			}),
+		}
+
+		logs = transformLogs(logs, nsTrans, false)
+		assert.Equal(t, mockTransLogs("c", "admin.$cmd", bson.D{
+			primitive.E{
+				Key: "applyOps",
+				Value: []bson.D{
+					{
+						primitive.E{"op", "i"},
+						primitive.E{"ns", "fdb2.fcol1"},
+						primitive.E{"o", bson.D{primitive.E{"a", 1}}},
+					},
+				},
+			},
+		}), logs[0], "should be equal")
+	}
 }
 
 func TestCalculateTop3(t *testing.T) {

--- a/oplog/apply_ops.go
+++ b/oplog/apply_ops.go
@@ -1,0 +1,51 @@
+package oplog
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// NormalizeApplyOps extracts and normalizes applyOps into []bson.D so callers
+// can share one BSON-container compatibility path while keeping their own
+// applyOps-specific behavior.
+func NormalizeApplyOps(logObject bson.D) ([]bson.D, error) {
+	raw := GetKey(logObject, "applyOps")
+	if raw == nil {
+		return nil, fmt.Errorf("applyOps field is missing")
+	}
+
+	switch v := raw.(type) {
+	case []bson.D:
+		return v, nil
+	case []bson.M:
+		ops := make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			ops = append(ops, ConvertBsonM2D(ele))
+		}
+		return ops, nil
+	case []any:
+		ops := make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			doc, ok := ele.(bson.D)
+			if !ok {
+				return nil, fmt.Errorf("applyOps element has unsupported type %T", ele)
+			}
+			ops = append(ops, doc)
+		}
+		return ops, nil
+	case primitive.A:
+		ops := make([]bson.D, 0, len(v))
+		for _, ele := range v {
+			doc, ok := ele.(bson.D)
+			if !ok {
+				return nil, fmt.Errorf("applyOps element has unsupported type %T", ele)
+			}
+			ops = append(ops, doc)
+		}
+		return ops, nil
+	default:
+		return nil, fmt.Errorf("applyOps field has unsupported type %T", raw)
+	}
+}

--- a/oplog/apply_ops_test.go
+++ b/oplog/apply_ops_test.go
@@ -1,0 +1,98 @@
+package oplog
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestNormalizeApplyOps(t *testing.T) {
+	// test NormalizeApplyOps
+
+	var nr int
+	newApplyOpsLog := func(value any) bson.D {
+		return bson.D{
+			{
+				Key:   "applyOps",
+				Value: value,
+			},
+		}
+	}
+
+	expected := []bson.D{
+		{
+			bson.E{Key: "op", Value: "i"},
+			bson.E{Key: "ns", Value: "db.col"},
+			bson.E{Key: "o", Value: bson.D{
+				bson.E{Key: "_id", Value: "doc-1"},
+			}},
+		},
+	}
+
+	{
+		fmt.Printf("TestNormalizeApplyOps case %d.\n", nr)
+		nr++
+
+		ops, err := NormalizeApplyOps(newApplyOpsLog(expected))
+		assert.NoError(t, err, "should be equal")
+		assert.Equal(t, expected, ops, "should be equal")
+	}
+
+	{
+		fmt.Printf("TestNormalizeApplyOps case %d.\n", nr)
+		nr++
+
+		ops, err := NormalizeApplyOps(newApplyOpsLog([]bson.M{
+			{
+				"op": "i",
+				"ns": "db.col",
+				"o":  bson.M{"_id": "doc-1"},
+			},
+		}))
+		assert.NoError(t, err, "should be equal")
+		assert.Equal(t, "i", GetKey(ops[0], "op"), "should be equal")
+		assert.Equal(t, "db.col", GetKey(ops[0], "ns"), "should be equal")
+		inner, ok := GetKey(ops[0], "o").(bson.M)
+		assert.True(t, ok, "should be equal")
+		assert.Equal(t, "doc-1", inner["_id"], "should be equal")
+	}
+
+	{
+		fmt.Printf("TestNormalizeApplyOps case %d.\n", nr)
+		nr++
+
+		ops, err := NormalizeApplyOps(newApplyOpsLog([]any{expected[0]}))
+		assert.NoError(t, err, "should be equal")
+		assert.Equal(t, expected, ops, "should be equal")
+	}
+
+	{
+		fmt.Printf("TestNormalizeApplyOps case %d.\n", nr)
+		nr++
+
+		ops, err := NormalizeApplyOps(newApplyOpsLog(primitive.A{expected[0]}))
+		assert.NoError(t, err, "should be equal")
+		assert.Equal(t, expected, ops, "should be equal")
+	}
+
+	{
+		fmt.Printf("TestNormalizeApplyOps case %d.\n", nr)
+		nr++
+
+		ops, err := NormalizeApplyOps(newApplyOpsLog(1))
+		assert.Nil(t, ops, "should be equal")
+		assert.EqualError(t, err, "applyOps field has unsupported type int")
+	}
+
+	{
+		fmt.Printf("TestNormalizeApplyOps case %d.\n", nr)
+		nr++
+
+		ops, err := NormalizeApplyOps(newApplyOpsLog([]any{"illegal"}))
+		assert.Nil(t, ops, "should be equal")
+		assert.EqualError(t, err, "applyOps element has unsupported type string")
+	}
+}


### PR DESCRIPTION
## 背景

在源端 MongoDB 开启 TTL、目标端作为冷库且不希望删除同步下发的场景下，源端因 TTL 触发的过期删除不应影响目标端数据。

为支持这一需求，本次改动新增了按 oplog 顶层 `op` 类型进行过滤的能力，用户可通过如下配置过滤 delete oplog：

```conf
filter.cmds = d
```

## 变更内容

- 在 `collector` 配置中新增 `filter.cmds`
- 在 `collector/filter` 中新增 `CmdFilter`
- 将 `CmdFilter` 接入增量同步的 oplog filter chain
- 为 `filter.cmds` 增加配置校验，非法值启动时直接报错，避免静默失效
- 更新 `conf/collector.conf` 中的配置说明与示例
- 补充相关测试，覆盖过滤逻辑与配置校验

## 行为说明

- 未配置 `filter.cmds` 时，行为与当前版本保持一致
- 配置 `filter.cmds=d` 时，顶层 `op=d` 的 oplog 会在下游处理前被过滤
- 当前实现仅支持按顶层 oplog `op` 类型过滤，不扩展到更复杂的表达式或嵌套语义

## 验证情况

- `go test ./cmd/collector -count=1`
- `go build ./cmd/collector`
- `go build ./collector/filter`

## 适用场景

- TTL delete 不下发冷库
- 需要按 oplog 操作类型做定向过滤的增量同步场景

## 兼容性

该改动默认兼容现有行为：

- 默认空配置不改变现有同步逻辑
- 仅在显式配置 `filter.cmds` 时启用对应过滤能力