### PR TITLE
feat: 支持 master_quorum 自定义 election_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ There are three options for parallel replication which we call 'shad\_key': __id
 ---
 Mongo-Shake periodically persistent its context into register center which by default is the source database. Currently, the context is checkpoint which marks the position of successfully replay oplog.<br>
 Hypervisor mechanism is also supported so that it will restart immediately when dies(`master_quorum` in configuration).
+`master_quorum` only supports `checkpoint.storage=database`; when `master_quorum=true`, `master_quorum.election_id` must be set to a valid MongoDB ObjectID and kept unique per independent sync job or HA group.
 
 # Filter
 ---

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -23,6 +23,24 @@ import (
 
 type Exit struct{ Code int }
 
+var (
+	fullSyncInitHttpApiFunc    = utils.FullSyncInitHttpApi
+	incrSyncInitHttpApiFunc    = utils.IncrSyncInitHttpApi
+	prometheusInitHttpApiFunc  = utils.PrometheusInitHttpApi
+	startPrometheusHttpApiFunc = startPrometheusHttpApi
+	registerConfHttpApiFunc    = registerConfHttpApi
+	selectLeaderFunc           = selectLeader
+	useElectionObjectIdFunc    = quorum.UseElectionObjectId
+	becomeMasterFunc           = quorum.BecomeMaster
+	alwaysMasterFunc           = quorum.AlwaysMaster
+	waitMasterPromotionFunc    = func() {
+		<-quorum.MasterPromotionNotifier
+	}
+	runReplicationFunc = func(replCord *coordinator.ReplicationCoordinator) error {
+		return replCord.Run()
+	}
+)
+
 func main() {
 	var err error
 	defer handleExit()
@@ -103,34 +121,10 @@ func main() {
 }
 
 func startup() {
-	// leader election at the beginning
-	selectLeader()
+	initStartupHTTPApis()
 
-	// initialize http api
-	utils.FullSyncInitHttpApi(conf.Options.FullSyncHTTPListenPort)
-	utils.IncrSyncInitHttpApi(conf.Options.IncrSyncHTTPListenPort)
-	utils.PrometheusInitHttpApi(conf.Options.PromHTTPListenPort)
 	ReplCord := &coordinator.ReplicationCoordinator{
 		MongoD: make([]*utils.MongoSource, len(conf.Options.MongoUrls)),
-	}
-
-	// register conf
-	utils.FullSyncHttpApi.RegisterAPI("/conf", nimo.HttpGet, func([]byte) interface{} {
-		return conf.GetSafeOptions()
-	})
-	utils.IncrSyncHttpApi.RegisterAPI("/conf", nimo.HttpGet, func([]byte) interface{} {
-		return conf.GetSafeOptions()
-	})
-
-	if utils.IsHTTPPortEnabled(conf.Options.PromHTTPListenPort) {
-		nimo.GoRoutine(func() {
-			if err := utils.PrometheusHttpApi.Listen(); err != nil {
-				l.Logger.Errorf("start prometheus server with port[%v] failed: %v",
-					conf.Options.PromHTTPListenPort, err)
-			}
-		})
-	} else {
-		l.Logger.Infof("prometheus http api disabled. port[%v]", conf.Options.PromHTTPListenPort)
 	}
 
 	// init
@@ -163,7 +157,7 @@ func startup() {
 	}
 
 	// start mongodb replication
-	if err := ReplCord.Run(); err != nil {
+	if err := runReplicationFunc(ReplCord); err != nil {
 		// initial or connection established failed
 		l.Logger.Errorf("run replication failed: %v", err)
 		crash(err.Error(), -6)
@@ -178,20 +172,57 @@ func startup() {
 	select {}
 }
 
+func initStartupHTTPApis() {
+	prometheusInitHttpApiFunc(conf.Options.PromHTTPListenPort)
+	startPrometheusHttpApiFunc()
+
+	// leader election blocks standby nodes before full/incr runtime APIs are exposed.
+	selectLeaderFunc()
+
+	fullSyncInitHttpApiFunc(conf.Options.FullSyncHTTPListenPort)
+	incrSyncInitHttpApiFunc(conf.Options.IncrSyncHTTPListenPort)
+	registerConfHttpApiFunc()
+}
+
+func registerConfHttpApi() {
+	utils.FullSyncHttpApi.RegisterAPI("/conf", nimo.HttpGet, func([]byte) interface{} {
+		return conf.GetSafeOptions()
+	})
+	utils.IncrSyncHttpApi.RegisterAPI("/conf", nimo.HttpGet, func([]byte) interface{} {
+		return conf.GetSafeOptions()
+	})
+}
+
+func startPrometheusHttpApi() {
+	if utils.IsHTTPPortEnabled(conf.Options.PromHTTPListenPort) {
+		nimo.GoRoutine(func() {
+			if err := utils.PrometheusHttpApi.Listen(); err != nil {
+				l.Logger.Errorf("start prometheus server with port[%v] failed: %v",
+					conf.Options.PromHTTPListenPort, err)
+			}
+		})
+	} else {
+		l.Logger.Infof("prometheus http api disabled. port[%v]", conf.Options.PromHTTPListenPort)
+	}
+}
+
 func selectLeader() {
 	// first of all. ensure we are the Master
 	if conf.Options.MasterQuorum && conf.Options.CheckpointStorage == utils.VarCheckpointStorageDatabase {
 		// election become to Master. keep waiting if we are the candidate. election id must be fixed
-		objectId, _ := primitive.ObjectIDFromHex("5204af979955496907000001")
-		quorum.UseElectionObjectId(objectId)
+		objectId, err := primitive.ObjectIDFromHex(conf.Options.MasterQuorumElectionID)
+		if err != nil {
+			crash(fmt.Sprintf("master_quorum.election_id is invalid: %v", err), -4)
+		}
+		useElectionObjectIdFunc(objectId)
 		go func() {
-			_ = quorum.BecomeMaster(conf.Options.CheckpointStorageUrl, utils.VarCheckpointStorageDbReplicaDefault)
+			_ = becomeMasterFunc(conf.Options.CheckpointStorageUrl, utils.VarCheckpointStorageDbReplicaDefault)
 		}()
 
 		// wait until become to a real master
-		<-quorum.MasterPromotionNotifier
+		waitMasterPromotionFunc()
 	} else {
-		quorum.AlwaysMaster()
+		alwaysMasterFunc()
 	}
 }
 

--- a/cmd/collector/collector_test.go
+++ b/cmd/collector/collector_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	conf "github.com/alibaba/MongoShake/v2/collector/configure"
+	utils "github.com/alibaba/MongoShake/v2/common"
+)
+
+func TestInitStartupHTTPApisStartPrometheusBeforeLeaderElection(t *testing.T) {
+	origin := conf.Options
+	originPrometheusInit := prometheusInitHttpApiFunc
+	originStartPrometheus := startPrometheusHttpApiFunc
+	originSelectLeader := selectLeaderFunc
+	originFullSyncInit := fullSyncInitHttpApiFunc
+	originIncrSyncInit := incrSyncInitHttpApiFunc
+	originRegisterConf := registerConfHttpApiFunc
+	defer func() {
+		conf.Options = origin
+		prometheusInitHttpApiFunc = originPrometheusInit
+		startPrometheusHttpApiFunc = originStartPrometheus
+		selectLeaderFunc = originSelectLeader
+		fullSyncInitHttpApiFunc = originFullSyncInit
+		incrSyncInitHttpApiFunc = originIncrSyncInit
+		registerConfHttpApiFunc = originRegisterConf
+	}()
+
+	conf.Options = conf.Configuration{
+		FullSyncHTTPListenPort: 9101,
+		IncrSyncHTTPListenPort: 9100,
+		PromHTTPListenPort:     9102,
+	}
+
+	order := make(chan string, 8)
+	leaderEntered := make(chan struct{})
+	releaseLeader := make(chan struct{})
+	done := make(chan struct{})
+
+	prometheusInitHttpApiFunc = func(int) {
+		order <- "prometheus-init"
+	}
+	startPrometheusHttpApiFunc = func() {
+		order <- "prometheus-listen"
+	}
+	selectLeaderFunc = func() {
+		order <- "select-leader"
+		close(leaderEntered)
+		<-releaseLeader
+	}
+	fullSyncInitHttpApiFunc = func(int) {
+		order <- "full-sync-init"
+	}
+	incrSyncInitHttpApiFunc = func(int) {
+		order <- "incr-sync-init"
+	}
+	registerConfHttpApiFunc = func() {
+		order <- "register-conf"
+	}
+
+	go func() {
+		initStartupHTTPApis()
+		close(done)
+	}()
+
+	waitClosed(t, leaderEntered, "leader election was not reached")
+	assert.Equal(t, "prometheus-init", readOrder(t, order), "should be equal")
+	assert.Equal(t, "prometheus-listen", readOrder(t, order), "should be equal")
+	assert.Equal(t, "select-leader", readOrder(t, order), "should be equal")
+
+	select {
+	case item := <-order:
+		t.Fatalf("unexpected startup step before leader election released: %s", item)
+	default:
+	}
+
+	close(releaseLeader)
+	waitClosed(t, done, "startup HTTP initialization did not finish")
+	assert.Equal(t, "full-sync-init", readOrder(t, order), "should be equal")
+	assert.Equal(t, "incr-sync-init", readOrder(t, order), "should be equal")
+	assert.Equal(t, "register-conf", readOrder(t, order), "should be equal")
+}
+
+func TestSelectLeaderUseConfiguredElectionID(t *testing.T) {
+	origin := conf.Options
+	originUseElectionObjectId := useElectionObjectIdFunc
+	originBecomeMaster := becomeMasterFunc
+	originWaitMasterPromotion := waitMasterPromotionFunc
+	defer func() {
+		conf.Options = origin
+		useElectionObjectIdFunc = originUseElectionObjectId
+		becomeMasterFunc = originBecomeMaster
+		waitMasterPromotionFunc = originWaitMasterPromotion
+	}()
+
+	expected, err := primitive.ObjectIDFromHex("66e3ffdd9df1af8e2308fb53")
+	assert.NoError(t, err, "should be equal")
+
+	var actual primitive.ObjectID
+	becomeMasterCall := make(chan struct {
+		uri string
+		db  string
+	}, 1)
+	useElectionObjectIdFunc = func(objectID primitive.ObjectID) {
+		actual = objectID
+	}
+	becomeMasterFunc = func(uri string, db string) error {
+		becomeMasterCall <- struct {
+			uri string
+			db  string
+		}{uri: uri, db: db}
+		return nil
+	}
+	waitMasterPromotionFunc = func() {}
+
+	conf.Options = conf.Configuration{
+		MasterQuorum:           true,
+		MasterQuorumElectionID: expected.Hex(),
+		CheckpointStorage:      utils.VarCheckpointStorageDatabase,
+		CheckpointStorageUrl:   "mongodb://checkpoint",
+	}
+
+	selectLeader()
+
+	assert.Equal(t, expected, actual, "should be equal")
+	call := readBecomeMasterCall(t, becomeMasterCall)
+	assert.Equal(t, "mongodb://checkpoint", call.uri, "should be equal")
+	assert.Equal(t, utils.VarCheckpointStorageDbReplicaDefault, call.db, "should be equal")
+}
+
+func waitClosed(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(msg)
+	}
+}
+
+func readOrder(t *testing.T, order <-chan string) string {
+	t.Helper()
+	select {
+	case item := <-order:
+		return item
+	case <-time.After(time.Second):
+		t.Fatal("startup step was not recorded")
+	}
+	return ""
+}
+
+func readBecomeMasterCall(t *testing.T, calls <-chan struct {
+	uri string
+	db  string
+}) struct {
+	uri string
+	db  string
+} {
+	t.Helper()
+	select {
+	case call := <-calls:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("BecomeMaster was not called")
+	}
+	return struct {
+		uri string
+		db  string
+	}{}
+}

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/filter"
 	utils "github.com/alibaba/MongoShake/v2/common"
@@ -166,6 +168,9 @@ func checkDefaultValue() error {
 	if conf.Options.CheckpointInterval <= 0 {
 		conf.Options.CheckpointInterval = 5000 // ms
 	}
+	if err := checkMasterQuorumOptions(); err != nil {
+		return err
+	}
 
 	// 2. full sync
 	if conf.Options.FullSyncReaderCollectionParallel <= 0 {
@@ -305,6 +310,22 @@ func checkDefaultValue() error {
 	filter.NsShouldBeIgnore[utils.AppDatabase+"."] = true
 	filter.NsShouldBeIgnore[utils.APPConflictDatabase+"."] = true
 
+	return nil
+}
+
+func checkMasterQuorumOptions() error {
+	if !conf.Options.MasterQuorum {
+		return nil
+	}
+	if conf.Options.CheckpointStorage != utils.VarCheckpointStorageDatabase {
+		return fmt.Errorf("context storage should set to 'database' while master election enabled")
+	}
+	if conf.Options.MasterQuorumElectionID == "" {
+		return fmt.Errorf("master_quorum.election_id should be given while master election enabled")
+	}
+	if _, err := primitive.ObjectIDFromHex(conf.Options.MasterQuorumElectionID); err != nil {
+		return fmt.Errorf("master_quorum.election_id should be a valid ObjectID: %v", err)
+	}
 	return nil
 }
 

--- a/cmd/collector/sanitize_test.go
+++ b/cmd/collector/sanitize_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
+	utils "github.com/alibaba/MongoShake/v2/common"
 )
 
 func TestNormalizeFilterOpTypes(t *testing.T) {
@@ -52,6 +53,55 @@ func TestCheckDefaultValueKeepDisabledHTTPPorts(t *testing.T) {
 	assert.Equal(t, -1, conf.Options.FullSyncHTTPListenPort, "should be equal")
 	assert.Equal(t, 0, conf.Options.IncrSyncHTTPListenPort, "should be equal")
 	assert.Equal(t, 0, conf.Options.PromHTTPListenPort, "should be equal")
+}
+
+func TestCheckDefaultValueRequireMasterQuorumElectionID(t *testing.T) {
+	origin := conf.Options
+	defer func() {
+		conf.Options = origin
+	}()
+
+	conf.Options = conf.Configuration{
+		MasterQuorum: true,
+		MongoUrls:    []string{"mongodb://source-a"},
+	}
+
+	err := checkDefaultValue()
+	assert.EqualError(t, err, "master_quorum.election_id should be given while master election enabled")
+}
+
+func TestCheckDefaultValueRejectInvalidMasterQuorumElectionID(t *testing.T) {
+	origin := conf.Options
+	defer func() {
+		conf.Options = origin
+	}()
+
+	conf.Options = conf.Configuration{
+		MasterQuorum:           true,
+		MasterQuorumElectionID: "invalid-object-id",
+		MongoUrls:              []string{"mongodb://source-a"},
+	}
+
+	err := checkDefaultValue()
+	assert.Error(t, err, "should be equal")
+	assert.Contains(t, err.Error(), "master_quorum.election_id should be a valid ObjectID")
+}
+
+func TestCheckDefaultValueAcceptMasterQuorumElectionID(t *testing.T) {
+	origin := conf.Options
+	defer func() {
+		conf.Options = origin
+	}()
+
+	conf.Options = conf.Configuration{
+		MasterQuorum:           true,
+		MasterQuorumElectionID: "66e3ffdd9df1af8e2308fb53",
+		MongoUrls:              []string{"mongodb://source-a"},
+	}
+
+	err := checkDefaultValue()
+	assert.NoError(t, err, "should be equal")
+	assert.Equal(t, utils.VarCheckpointStorageDatabase, conf.Options.CheckpointStorage, "should be equal")
 }
 
 func TestCheckConflictRejectPrometheusHTTPPortConflict(t *testing.T) {

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -13,6 +13,7 @@ type Configuration struct {
 	// 1. global
 	Id                                     string   `config:"id"`
 	MasterQuorum                           bool     `config:"master_quorum"`
+	MasterQuorumElectionID                 string   `config:"master_quorum.election_id"`
 	FullSyncHTTPListenPort                 int      `config:"full_sync.http_port"`
 	IncrSyncHTTPListenPort                 int      `config:"incr_sync.http_port"`
 	PromHTTPListenPort                     int      `config:"prom.http_port"`

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -20,6 +20,11 @@ id = mongoshake
 # This option is useless when there is only one mongoshake running.
 # 如果开启主备mongoshake拉取同一个源端，此参数需要开启。
 master_quorum = false
+# master_quorum only supports checkpoint.storage=database. When master_quorum=true,
+# master_quorum.election_id is required and should be unique per independent sync job or HA group.
+# master_quorum 仅支持 checkpoint.storage=database；开启后必须显式配置 master_quorum.election_id，
+# 且每个独立同步任务或 HA 组应使用不同的 election id。
+# master_quorum.election_id = 66e3ffdd9df1af8e2308fb53
 
 # http api interface. Users can use this api to monitor mongoshake.
 # `curl 127.0.0.1:9100`.


### PR DESCRIPTION
## 背景

当前 `collector` 的主备选举使用固定的 election document `_id`。当多组独立同步任务共用同一个 checkpoint DB 时，会竞争同一条 election 文档，导致不同任务之间互相影响选主。

本 PR 增加 `master_quorum.election_id` 配置项，让每组独立同步任务 / HA 组可以显式配置自己的 election id。

## 主要改动

- 新增 `master_quorum.election_id` 配置读取。
- 在启动校验阶段检查：
  - `master_quorum=true` 时必须使用 `checkpoint.storage=database`
  - `master_quorum.election_id` 必填
  - `master_quorum.election_id` 必须是合法 MongoDB ObjectID
- 去掉 `selectLeader()` 中写死的 election `_id`。
- 将 Prometheus `/metrics` 启动前移到阻塞式选主之前。
- 保持 `full_sync` / `incr_sync` HTTP API 在成为 master 后再初始化和暴露。
- 更新 README 和 `conf/collector.conf` 中的配置说明。
- 补充启动顺序和 election id 校验测试。

## `cmd/collector/collector.go` 的改动思路

### 1. 调整启动顺序

原来的启动路径中，collector 会先进入 `selectLeader()`。在 standby 场景下，进程会阻塞等待成为 master，因此后续 HTTP 初始化逻辑不会执行。

本 PR 将 Prometheus 的初始化和监听移动到 `selectLeader()` 之前，使 standby collector 也可以暴露 `/metrics`，方便监控系统采集。

调整后的顺序是：

- 初始化并启动 Prometheus HTTP
- 进入 `selectLeader()`
- 成为 master 后初始化 full/incr HTTP provider
- 注册 `/conf` API
- 启动 replication coordinator

### 2. 只前移 Prometheus，不前移 full/incr HTTP API

`full_sync` / `incr_sync` HTTP API 属于运行态业务接口。

standby 实例还没有进入同步流程，如果提前暴露这些 API，容易让使用者误以为实例已经可提供正常同步状态查询。因此这两个 provider 仍然放在 `selectLeader()` 返回之后初始化。

对外行为是：

- standby 阶段可以访问 Prometheus `/metrics`
- full/incr API 仍只在成为 master 后进入运行态再暴露

### 3. 保持 HTTP provider 结构一致

本 PR 继续使用现有的 `utils.PrometheusInitHttpApi` 和 `PrometheusHttpApi.Listen()` 来启动 Prometheus。

这样 collector 入口层不需要新增另一套 HTTP 启动方式，Prometheus、full_sync、incr_sync 的 HTTP provider 结构也保持一致。

### 4. 拆出启动顺序 helper

原来的 `startup()` 同时包含选主、HTTP 初始化、coordinator 构造、Mongo source 初始化和 replication 启动，启动顺序不够直观。

本 PR 将 HTTP 相关顺序抽到 `initStartupHTTPApis()`：

- `prometheusInitHttpApiFunc(...)`
- `startPrometheusHttpApiFunc()`
- `selectLeaderFunc()`
- `fullSyncInitHttpApiFunc(...)`
- `incrSyncInitHttpApiFunc(...)`
- `registerConfHttpApiFunc()`

这样可以清楚表达 Prometheus、选主、full/incr API 三者的先后关系，也方便后续维护。

### 5. `selectLeader()` 改为读取配置中的 election id

原来 `selectLeader()` 使用写死 ObjectID。

现在改为读取 `conf.Options.MasterQuorumElectionID`，解析为 MongoDB ObjectID 后传给 `quorum.UseElectionObjectId()`。

如果配置值不是合法 ObjectID，启动会显式失败并输出错误信息，避免把非法 election id 带入 quorum 选主逻辑。

### 6. 增加内部 function seam 方便测试

新增的 package-level function 变量只在 `cmd/collector` 包内部使用，不改变对外接口和运行时语义，主要用于单测替换有副作用的函数。

这些真实函数不适合直接在单测里调用：

- `PrometheusHttpApi.Listen()` 会真实监听端口
- `selectLeader()` 在 standby 场景下会阻塞
- `quorum.BecomeMaster()` 会连接 MongoDB 并进入选主循环
- `ReplicationCoordinator.Run()` 会进入真实同步链路

通过这些内部 seam，测试可以验证启动顺序和 election id 接线，而不需要真实监听端口、连接 MongoDB 或启动同步。


关联ISSUE：https://github.com/alibaba/MongoShake/issues/96
