### PR TITLE
comparison_3x: ensure MongoCluster cleanup on all exit paths

### DIFF
--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -7,6 +7,18 @@ import time
 import sys
 import getopt
 
+
+def _safe_close_mongo_cluster(cluster):
+    if cluster is None:
+        return
+    conn = getattr(cluster, "conn", None)
+    if conn is None:
+        return
+    try:
+        cluster.close()
+    except Exception:
+        pass
+
 # constant
 COMPARISION_COUNT = "comparison_count"
 COMPARISION_MODE = "comparisonMode"
@@ -235,6 +247,7 @@ if __name__ == "__main__":
     # dump configuration
     log_info("Configuration [sample=%s, count=%d, excludeDbs=%s, excludeColls=%s]" % (configure[SAMPLE], configure[COMPARISION_COUNT], configure[EXCLUDE_DBS], configure[EXCLUDE_COLLS]))
 
+    src, dst = None, None
     try :
         src, dst = MongoCluster(srcUrl), MongoCluster(dstUrl)
         print("[src = %s]" % srcUrl)
@@ -244,14 +257,17 @@ if __name__ == "__main__":
     except (Exception, e):
         print(e)
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)
         exit()
 
-    if check(src, dst):
-        print("SUCCESS")
-        exit(0)
-    else:
-        print("FAIL")
-        exit(-1)
-
-    src.close()
-    dst.close()
+    try:
+        if check(src, dst):
+            print("SUCCESS")
+            exit(0)
+        else:
+            print("FAIL")
+            exit(-1)
+    finally:
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -264,10 +264,10 @@ if __name__ == "__main__":
     try:
         if check(src, dst):
             print("SUCCESS")
-            exit(0)
+            sys.exit(0)
         else:
             print("FAIL")
-            exit(-1)
+            sys.exit(-1)
     finally:
         _safe_close_mongo_cluster(src)
         _safe_close_mongo_cluster(dst)

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -259,7 +259,7 @@ if __name__ == "__main__":
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
         _safe_close_mongo_cluster(src)
         _safe_close_mongo_cluster(dst)
-        exit()
+        sys.exit(1)
 
     try:
         if check(src, dst):

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -254,7 +254,7 @@ if __name__ == "__main__":
         print("[dst = %s]" % dstUrl)
         src.connect()
         dst.connect()
-    except (Exception, e):
+    except Exception as e:
         print(e)
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
         _safe_close_mongo_cluster(src)

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -4,7 +4,6 @@
 
 import pymongo
 import time
-import random
 import sys
 import getopt
 
@@ -256,5 +255,3 @@ if __name__ == "__main__":
 
     src.close()
     dst.close()
-
-

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -216,9 +216,9 @@ def data_comparison(srcColl, dstColl, mode):
 
 def usage():
     print('|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|')
-    print("| Usage: ./comparison.py --src=localhost:27017/db? --dest=localhost:27018/db? --count=10000 (the sample number) --excludeDbs=admin,local --excludeCollections=system.profile --comparisonMode=sample/all/no (sample: comparison sample number, default; all: comparison all data; no: only comparison outline without data)  |")
+    print("| Usage: ./comparison_3x.py --src=localhost:27017/db? --dest=localhost:27018/db? --count=10000 (the sample number) --excludeDbs=admin,local --excludeCollections=system.profile --comparisonMode=sample/all/no (sample: comparison sample number, default; all: comparison all data; no: only comparison outline without data)  |")
     print('|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|')
-    print('| Like : ./comparison.py --src="localhost:3001" --dest=localhost:3100  --count=1000  --excludeDbs=admin,local,mongoshake --excludeCollections=system.profile --comparisonMode=sample  |')
+    print('| Like : ./comparison_3x.py --src="localhost:3001" --dest=localhost:3100  --count=1000  --excludeDbs=admin,local,mongoshake --excludeCollections=system.profile --comparisonMode=sample  |')
     print('|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|')
     exit(0)
 

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -4,7 +4,6 @@
 
 import pymongo
 import time
-import random
 import sys
 import getopt
 import math
@@ -288,5 +287,3 @@ if __name__ == "__main__":
 
     src.close()
     dst.close()
-
-

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -8,6 +8,18 @@ import sys
 import getopt
 import math
 
+
+def _safe_close_mongo_cluster(cluster):
+    if cluster is None:
+        return
+    conn = getattr(cluster, "conn", None)
+    if conn is None:
+        return
+    try:
+        cluster.close()
+    except Exception:
+        pass
+
 # constant
 COMPARISON_COUNT = "comparison_count"
 COMPARISON_MODE = "comparisonMode"
@@ -267,23 +279,27 @@ if __name__ == "__main__":
     # dump configuration
     log_info("Configuration [sample=%s, count=%d, excludeDbs=%s, excludeColls=%s]" % (configure[SAMPLE], configure[COMPARISON_COUNT], configure[EXCLUDE_DBS], configure[EXCLUDE_COLLS]))
 
-    try :
+    src, dst = None, None
+    try:
         src, dst = MongoCluster(srcUrl), MongoCluster(dstUrl)
         print("[src = %s]" % srcUrl)
         print("[dst = %s]" % dstUrl)
         src.connect()
         dst.connect()
-    except (Exception, e):
+    except Exception as e:
         print(e)
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
-        exit()
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)
+        sys.exit(1)
 
-    if check(src, dst):
-        print("SUCCESS")
-        exit(0)
-    else:
-        print("FAIL")
-        exit(-1)
-
-    src.close()
-    dst.close()
+    try:
+        if check(src, dst):
+            print("SUCCESS")
+            sys.exit(0)
+        else:
+            print("FAIL")
+            sys.exit(-1)
+    finally:
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)


### PR DESCRIPTION
# Summary
Ensure MongoDB client connections are closed on success, failure, and connection errors. Replace unreachable `close()` calls after `exit()` with a `try`/`finally` pattern and a safe-close helper. Fix the connection error handler for Python 3.
# Problem
- `src.close()` / `dst.close()` were placed after `exit(0)` / `exit(-1)`, so they never executed.
- `except (Exception, e):` is not valid Python 3 exception syntax.
# Solution
- Add `_safe_close_mongo_cluster()` to close only when a cluster exists and `conn` is set, and to avoid cleanup raising secondary errors.
- On connect failure: close any opened clients, then `sys.exit(1)`.
- After successful connect: run `check()` in a `try`/`finally` and call the helper in `finally` so cleanup runs even when `sys.exit(0)` or `sys.exit(-1)` is used.
# Testing
- [ ] Run with valid `--src` / `--dest`: SUCCESS/FAIL and exit codes unchanged.
- [ ] Run with invalid URI: connection error, exit code 1, no traceback from `close()`.