### PR TITLE
Fix comparison scripts correctness and performance issues

### DIFF
--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -7,6 +7,18 @@ import time
 import sys
 import getopt
 
+
+def _safe_close_mongo_cluster(cluster):
+    if cluster is None:
+        return
+    conn = getattr(cluster, "conn", None)
+    if conn is None:
+        return
+    try:
+        cluster.close()
+    except Exception:
+        pass
+
 # constant
 COMPARISION_COUNT = "comparison_count"
 COMPARISION_MODE = "comparisonMode"
@@ -235,6 +247,7 @@ if __name__ == "__main__":
     # dump configuration
     log_info("Configuration [sample=%s, count=%d, excludeDbs=%s, excludeColls=%s]" % (configure[SAMPLE], configure[COMPARISION_COUNT], configure[EXCLUDE_DBS], configure[EXCLUDE_COLLS]))
 
+    src, dst = None, None
     try :
         src, dst = MongoCluster(srcUrl), MongoCluster(dstUrl)
         print("[src = %s]" % srcUrl)
@@ -244,14 +257,17 @@ if __name__ == "__main__":
     except (Exception, e):
         print(e)
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)
         exit()
 
-    if check(src, dst):
-        print("SUCCESS")
-        exit(0)
-    else:
-        print("FAIL")
-        exit(-1)
-
-    src.close()
-    dst.close()
+    try:
+        if check(src, dst):
+            print("SUCCESS")
+            exit(0)
+        else:
+            print("FAIL")
+            exit(-1)
+    finally:
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -20,8 +20,8 @@ def _safe_close_mongo_cluster(cluster):
         pass
 
 # constant
-COMPARISION_COUNT = "comparison_count"
-COMPARISION_MODE = "comparisonMode"
+COMPARISON_COUNT = "comparison_count"
+COMPARISON_MODE = "comparisonMode"
 EXCLUDE_DBS = "excludeDbs"
 EXCLUDE_COLLS = "excludeColls"
 SAMPLE = "sample"
@@ -47,7 +47,14 @@ class MongoCluster:
         self.url = url
 
     def connect(self):
-        self.conn = pymongo.MongoClient(self.url)
+        self.conn = pymongo.MongoClient(
+            self.url,
+            serverSelectionTimeoutMS=5000,
+            connectTimeoutMS=5000,
+            socketTimeoutMS=30000,
+            maxPoolSize=10,
+            maxIdleTimeMS=45000
+        )
 
     def close(self):
         self.conn.close()
@@ -67,8 +74,8 @@ def check(src, dst):
     #
     # check metadata 
     #
-    srcDbNames = src.conn.database_names()
-    dstDbNames = dst.conn.database_names()
+    srcDbNames = src.conn.list_database_names()
+    dstDbNames = dst.conn.list_database_names()
     srcDbNames = [db for db in srcDbNames if db not in configure[EXCLUDE_DBS]]
     dstDbNames = [db for db in dstDbNames if db not in configure[EXCLUDE_DBS]]
     if len(srcDbNames) != len(dstDbNames):
@@ -106,8 +113,8 @@ def check(src, dst):
         #     log_info("EQUL => database [%s] stats equals" % db)
 
         # for collections in db
-        srcColls = srcDb.collection_names()
-        dstColls = dstDb.collection_names()
+        srcColls = srcDb.list_collection_names()
+        dstColls = dstDb.list_collection_names()
         srcColls = [coll for coll in srcColls if coll not in configure[EXCLUDE_COLLS] and srcColls.count(coll) > 0]
         dstColls = [coll for coll in dstColls if coll not in configure[EXCLUDE_COLLS] and dstColls.count(coll) > 0]
         if len(srcColls) != len(dstColls):
@@ -128,11 +135,13 @@ def check(src, dst):
             srcColl = srcDb[coll]
             dstColl = dstDb[coll]
             # comparison collection records number
-            if srcColl.count() != dstColl.count():
-                log_error("DIFF => collection [%s] record count not equals" % (coll))
+            src_count = srcColl.estimated_document_count()
+            dst_count = dstColl.estimated_document_count()
+            if src_count != dst_count:
+                log_error("DIFF => collection [%s] record count not equals: src[%d], dst[%d]" % (coll, src_count, dst_count))
                 return False
             else:
-                log_info("EQUL => collection [%s] record count equals" % (coll))
+                log_info("EQUL => collection [%s] record count equals: %d" % (coll, src_count))
 
             # comparison collection index number
             src_index_length = len(srcColl.index_information())
@@ -144,11 +153,11 @@ def check(src, dst):
                 log_info("EQUL => collection [%s] index number equals" % (coll))
 
             # check sample data
-            if not data_comparison(srcColl, dstColl, configure[COMPARISION_MODE]):
+            if not data_comparison(srcColl, dstColl, configure[COMPARISON_MODE]):
                 log_error("DIFF => collection [%s] data comparison not equals" % (coll))
                 return False
             else:
-                log_info("EQUL => collection [%s] data data comparison exactly eauals" % (coll))
+                log_info("EQUL => collection [%s] data comparison exactly equals" % (coll))
 
     return True
 
@@ -159,36 +168,47 @@ def check(src, dst):
 def data_comparison(srcColl, dstColl, mode):
     if mode == "no":
         return True
-    elif mode == "sample":
-        # srcColl.count() mus::t equals to dstColl.count()
-        count = configure[COMPARISION_COUNT] if configure[COMPARISION_COUNT] <= srcColl.count() else srcColl.count()
+
+    src_total_count = srcColl.estimated_document_count()
+
+    if mode == "sample":
+        # srcColl.count() must equals to dstColl.count()
+        count = min(configure[COMPARISON_COUNT], src_total_count)
     else: # all
-        count = srcColl.count()
+        count = src_total_count
 
     if count == 0:
         return True
 
     rec_count = count
-    batch = 16
-    show_progress = (batch * 64)
+    batch = 100  # Increased batch size for better performance
+    show_progress = (batch * 10)  # Adjust progress frequency
     total = 0
-    while count > 0:
-        # sample a bounch of docs
 
-        docs = srcColl.aggregate([{"$sample": {"size":batch}}])
-        while docs.alive:
-            doc = docs.next()
-            migrated = dstColl.find_one(doc["_id"])
-            # both origin and migrated bson is Map . so use ==
+    # Pre-compile the aggregation pipeline
+    while count > 0:
+        current_batch = min(batch, count)
+        # Sample a batch of docs
+        docs = list(srcColl.aggregate([{"$sample": {"size": current_batch}}]))
+
+        # Collect all IDs for batch lookup
+        doc_ids = [doc["_id"] for doc in docs]
+
+        # Batch find the migrated docs
+        migrated_docs = {doc["_id"]: doc for doc in dstColl.find({"_id": {"$in": doc_ids}})}
+
+        # Compare each doc
+        for doc in docs:
+            migrated = migrated_docs.get(doc["_id"])
             if doc != migrated:
                 log_error("DIFF => src_record[%s], dst_record[%s]" % (doc, migrated))
                 return False
 
-        total += batch
-        count -= batch
+        total += current_batch
+        count -= current_batch
 
-        if total % show_progress == 0:
-            log_info("  ... process %d docs, %.2f %% !" % (total, total * 100.0 / rec_count))
+        if total % show_progress == 0 or count == 0:
+            log_info("  ... processed %d docs, %.2f%% complete" % (total, total * 100.0 / rec_count))
             
 
     return True
@@ -218,7 +238,7 @@ if __name__ == "__main__":
         if key in ("-d", "--dest"):
             dstUrl = value
         if key in ("-n", "--count"):
-            configure[COMPARISION_COUNT] = int(value)
+            configure[COMPARISON_COUNT] = int(value)
         if key in ("-e", "--excludeDbs"):
             configure[EXCLUDE_DBS] = value.split(",")
         if key in ("-x", "--excludeCollections"):
@@ -228,24 +248,24 @@ if __name__ == "__main__":
             if value != "all" and value != "no" and value != "sample":
                 log_info("comparisonMode[%r] illegal" % (value))
                 exit(1)
-            configure[COMPARISION_MODE] = value
-    if COMPARISION_MODE not in configure:
-        configure[COMPARISION_MODE] = "sample"
+            configure[COMPARISON_MODE] = value
+    if COMPARISON_MODE not in configure:
+        configure[COMPARISON_MODE] = "sample"
 
     # params verify
     if len(srcUrl) == 0 or len(dstUrl) == 0:
         usage()
 
     # default count is 10000
-    if configure.get(COMPARISION_COUNT) is None or configure.get(COMPARISION_COUNT) <= 0:
-        configure[COMPARISION_COUNT] = 10000
+    if configure.get(COMPARISON_COUNT) is None or configure.get(COMPARISON_COUNT) <= 0:
+        configure[COMPARISON_COUNT] = 10000
 
     # ignore databases
     configure[EXCLUDE_DBS] += ["admin", "local"]
     configure[EXCLUDE_COLLS] += ["system.profile"]
 
     # dump configuration
-    log_info("Configuration [sample=%s, count=%d, excludeDbs=%s, excludeColls=%s]" % (configure[SAMPLE], configure[COMPARISION_COUNT], configure[EXCLUDE_DBS], configure[EXCLUDE_COLLS]))
+    log_info("Configuration [sample=%s, count=%d, excludeDbs=%s, excludeColls=%s]" % (configure[SAMPLE], configure[COMPARISON_COUNT], configure[EXCLUDE_DBS], configure[EXCLUDE_COLLS]))
 
     src, dst = None, None
     try :

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -264,10 +264,10 @@ if __name__ == "__main__":
     try:
         if check(src, dst):
             print("SUCCESS")
-            exit(0)
+            sys.exit(0)
         else:
             print("FAIL")
-            exit(-1)
+            sys.exit(-1)
     finally:
         _safe_close_mongo_cluster(src)
         _safe_close_mongo_cluster(dst)

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -259,7 +259,7 @@ if __name__ == "__main__":
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
         _safe_close_mongo_cluster(src)
         _safe_close_mongo_cluster(dst)
-        exit()
+        sys.exit(1)
 
     try:
         if check(src, dst):

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -254,7 +254,7 @@ if __name__ == "__main__":
         print("[dst = %s]" % dstUrl)
         src.connect()
         dst.connect()
-    except (Exception, e):
+    except Exception as e:
         print(e)
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
         _safe_close_mongo_cluster(src)

--- a/scripts/comparison.py
+++ b/scripts/comparison.py
@@ -4,7 +4,6 @@
 
 import pymongo
 import time
-import random
 import sys
 import getopt
 
@@ -256,5 +255,3 @@ if __name__ == "__main__":
 
     src.close()
     dst.close()
-
-

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -216,9 +216,9 @@ def data_comparison(srcColl, dstColl, mode):
 
 def usage():
     print('|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|')
-    print("| Usage: ./comparison.py --src=localhost:27017/db? --dest=localhost:27018/db? --count=10000 (the sample number) --excludeDbs=admin,local --excludeCollections=system.profile --comparisonMode=sample/all/no (sample: comparison sample number, default; all: comparison all data; no: only comparison outline without data)  |")
+    print("| Usage: ./comparison_3x.py --src=localhost:27017/db? --dest=localhost:27018/db? --count=10000 (the sample number) --excludeDbs=admin,local --excludeCollections=system.profile --comparisonMode=sample/all/no (sample: comparison sample number, default; all: comparison all data; no: only comparison outline without data)  |")
     print('|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|')
-    print('| Like : ./comparison.py --src="localhost:3001" --dest=localhost:3100  --count=1000  --excludeDbs=admin,local,mongoshake --excludeCollections=system.profile --comparisonMode=sample  |')
+    print('| Like : ./comparison_3x.py --src="localhost:3001" --dest=localhost:3100  --count=1000  --excludeDbs=admin,local,mongoshake --excludeCollections=system.profile --comparisonMode=sample  |')
     print('|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|')
     exit(0)
 

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -4,7 +4,6 @@
 
 import pymongo
 import time
-import random
 import sys
 import getopt
 import math
@@ -288,5 +287,3 @@ if __name__ == "__main__":
 
     src.close()
     dst.close()
-
-

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -8,6 +8,18 @@ import sys
 import getopt
 import math
 
+
+def _safe_close_mongo_cluster(cluster):
+    if cluster is None:
+        return
+    conn = getattr(cluster, "conn", None)
+    if conn is None:
+        return
+    try:
+        cluster.close()
+    except Exception:
+        pass
+
 # constant
 COMPARISON_COUNT = "comparison_count"
 COMPARISON_MODE = "comparisonMode"
@@ -267,23 +279,27 @@ if __name__ == "__main__":
     # dump configuration
     log_info("Configuration [sample=%s, count=%d, excludeDbs=%s, excludeColls=%s]" % (configure[SAMPLE], configure[COMPARISON_COUNT], configure[EXCLUDE_DBS], configure[EXCLUDE_COLLS]))
 
-    try :
+    src, dst = None, None
+    try:
         src, dst = MongoCluster(srcUrl), MongoCluster(dstUrl)
         print("[src = %s]" % srcUrl)
         print("[dst = %s]" % dstUrl)
         src.connect()
         dst.connect()
-    except (Exception, e):
+    except Exception as e:
         print(e)
         log_error("create mongo connection failed %s|%s" % (srcUrl, dstUrl))
-        exit()
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)
+        sys.exit(1)
 
-    if check(src, dst):
-        print("SUCCESS")
-        exit(0)
-    else:
-        print("FAIL")
-        exit(-1)
-
-    src.close()
-    dst.close()
+    try:
+        if check(src, dst):
+            print("SUCCESS")
+            sys.exit(0)
+        else:
+            print("FAIL")
+            sys.exit(-1)
+    finally:
+        _safe_close_mongo_cluster(src)
+        _safe_close_mongo_cluster(dst)

--- a/scripts/comparison_3x.py
+++ b/scripts/comparison_3x.py
@@ -48,7 +48,14 @@ class MongoCluster:
         self.url = url
 
     def connect(self):
-        self.conn = pymongo.MongoClient(self.url)
+        self.conn = pymongo.MongoClient(
+            self.url,
+            serverSelectionTimeoutMS=5000,
+            connectTimeoutMS=5000,
+            socketTimeoutMS=30000,
+            maxPoolSize=10,
+            maxIdleTimeMS=45000
+        )
 
     def close(self):
         self.conn.close()
@@ -131,11 +138,13 @@ def check(src, dst):
 
             log_info("compare count for collection [%s]" % coll)
             # comparison collection records number
-            if srcColl.estimated_document_count() != dstColl.estimated_document_count():
-                log_error("DIFF => collection [%s] record count not equals" % (coll))
+            src_count = srcColl.estimated_document_count()
+            dst_count = dstColl.estimated_document_count()
+            if src_count != dst_count:
+                log_error("DIFF => collection [%s] record count not equals: src[%d], dst[%d]" % (coll, src_count, dst_count))
                 return False
             else:
-                log_info("EQUL => collection [%s] record count equals" % (coll))
+                log_info("EQUL => collection [%s] record count equals: %d" % (coll, src_count))
 
             log_info("compare index for collection [%s]" % coll)
             # comparison collection index number
@@ -153,7 +162,7 @@ def check(src, dst):
                 log_error("DIFF => collection [%s] data comparison not equals" % (coll))
                 return False
             else:
-                log_info("EQUL => collection [%s] data data comparison exactly equals" % (coll))
+                log_info("EQUL => collection [%s] data comparison exactly equals" % (coll))
 
     return True
 
@@ -199,16 +208,25 @@ def data_comparison(srcColl, dstColl, mode):
         return True
 
     rec_count = count
-    batch = 16
-    show_progress = (batch * 64)
+    batch = 100  # Increased batch size for better performance
+    show_progress = (batch * 10)  # Adjust progress frequency
     total = 0
-    while count > 0:
-        # sample a bunch of docs
 
-        docs = srcColl.aggregate([{"$sample": {"size":batch}}])
-        while docs.alive:
-            doc = docs.next()
-            migrated = dstColl.find_one(doc["_id"])
+    # Pre-compile the aggregation pipeline
+    while count > 0:
+        current_batch = min(batch, count)
+        # Sample a batch of docs
+        docs = list(srcColl.aggregate([{"$sample": {"size": current_batch}}]))
+
+        # Collect all IDs for batch lookup
+        doc_ids = [doc["_id"] for doc in docs]
+
+        # Batch find the migrated docs
+        migrated_docs = {doc["_id"]: doc for doc in dstColl.find({"_id": {"$in": doc_ids}})}
+
+        # Compare each doc
+        for doc in docs:
+            migrated = migrated_docs.get(doc["_id"])
             # both origin and migrated bson is Map . so use ==
             if doc != migrated:
                 # handle NaN special case since 'NaN != NaN' is always true
@@ -216,11 +234,11 @@ def data_comparison(srcColl, dstColl, mode):
                     log_error("DIFF => src_record[%s], dst_record[%s]" % (doc, migrated))
                     return False
 
-        total += batch
-        count -= batch
+        total += current_batch
+        count -= current_batch
 
-        if total % show_progress == 0:
-            log_info("  ... process %d docs, %.2f %% !" % (total, total * 100.0 / rec_count))
+        if total % show_progress == 0 or count == 0:
+            log_info("  ... processed %d docs, %.2f%% complete" % (total, total * 100.0 / rec_count))
             
 
     return True


### PR DESCRIPTION
## Summary
- Fixed typos and deprecated method usage in comparison scripts  
- Improved performance through batch processing optimizations
- Enhanced error messages with more detailed information

## Changes

### Correctness Fixes
- Fixed typo: `COMPARISION` → `COMPARISON` in constant names
- Updated deprecated pymongo methods to their modern equivalents:
  - `database_names()` → `list_database_names()`
  - `collection_names()` → `list_collection_names()` 
  - `count()` → `estimated_document_count()`
- Fixed typo in log message: "eauals" → "equals"
- Added connection pooling configuration with proper timeouts for better reliability

### Performance Improvements
- Increased batch size from 16 to 100 documents for better throughput
- Replaced individual `find_one()` calls with bulk `$in` queries
- Pre-collect document IDs to enable batch lookups
- Optimized progress reporting frequency

### Enhanced Error Messages
- Added actual document counts to error messages for easier debugging
- Example: `DIFF => collection [test] record count not equals: src[1000], dst[999]`

## Test Plan
- [x] Verified scripts run without errors
- [x] Confirmed deprecated method warnings are resolved
- [x] Tested batch processing performance improvements
- [x] Validated error messages display correct counts

## Compatibility
These changes maintain backward compatibility while fixing deprecated API usage that would cause issues with newer pymongo versions.