### PR TITLE
Add configurable skip rules for duplicate insert conflicts after insert-on-dup update fallback

### DIFF
--- a/cmd/collector/collector_test.go
+++ b/cmd/collector/collector_test.go
@@ -131,6 +131,61 @@ func TestSelectLeaderUseConfiguredElectionID(t *testing.T) {
 	assert.Equal(t, utils.VarCheckpointStorageDbReplicaDefault, call.db, "should be equal")
 }
 
+func TestDupKeyStrategyDefaultAndValidation(t *testing.T) {
+	origin := conf.Options
+	defer func() { conf.Options = origin }()
+
+	conf.Options = conf.Configuration{MongoUrls: []string{"mongodb://127.0.0.1:27017"}}
+	assert.NoError(t, checkDefaultValue(), "should be equal")
+	assert.Equal(t, utils.VarIncrSyncExecutorDupKeyStrategyIgnore,
+		conf.Options.IncrSyncExecutorDupKeyStrategy, "should be equal")
+
+	for _, strategy := range []string{
+		utils.VarIncrSyncExecutorDupKeyStrategyIgnore,
+		utils.VarIncrSyncExecutorDupKeyStrategyError,
+		utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry,
+		utils.VarIncrSyncExecutorDupKeyStrategySkip,
+	} {
+		conf.Options = conf.Configuration{
+			MongoUrls:                       []string{"mongodb://127.0.0.1:27017"},
+			IncrSyncExecutorDupKeyStrategy: strategy,
+		}
+		if strategy == utils.VarIncrSyncExecutorDupKeyStrategySkip {
+			conf.Options.IncrSyncExecutorDupKeySkipRules = []string{"db.coll:x_1"}
+		}
+		assert.NoError(t, checkDefaultValue(), "strategy %s should be valid", strategy)
+	}
+
+	conf.Options = conf.Configuration{
+		MongoUrls:                       []string{"mongodb://127.0.0.1:27017"},
+		IncrSyncExecutorDupKeyStrategy: "bad",
+	}
+	assert.Error(t, checkDefaultValue(), "should be equal")
+}
+
+func TestParseDupKeySkipRules(t *testing.T) {
+	origin := conf.Options
+	defer func() { conf.Options = origin }()
+
+	conf.Options = conf.Configuration{
+		IncrSyncExecutorDupKeyStrategy:  utils.VarIncrSyncExecutorDupKeyStrategySkip,
+		IncrSyncExecutorDupKeySkipRules: []string{"db.a:x_1,y_1", "db.b:*"},
+	}
+	assert.NoError(t, parseDupKeySkipRules(), "should be equal")
+	_, ok := conf.Options.IncrSyncExecutorDupKeySkipRulesMap["db.a"]["x_1"]
+	assert.True(t, ok, "should be equal")
+	_, ok = conf.Options.IncrSyncExecutorDupKeySkipRulesMap["db.a"]["y_1"]
+	assert.True(t, ok, "should be equal")
+	_, ok = conf.Options.IncrSyncExecutorDupKeySkipRulesMap["db.b"]["*"]
+	assert.True(t, ok, "should be equal")
+
+	conf.Options = conf.Configuration{IncrSyncExecutorDupKeyStrategy: utils.VarIncrSyncExecutorDupKeyStrategySkip}
+	assert.Error(t, parseDupKeySkipRules(), "skip strategy requires rules")
+
+	conf.Options = conf.Configuration{IncrSyncExecutorDupKeySkipRules: []string{"db.coll:"}}
+	assert.Error(t, parseDupKeySkipRules(), "empty index should be rejected")
+}
+
 func waitClosed(t *testing.T, ch <-chan struct{}, msg string) {
 	t.Helper()
 	select {

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -299,11 +299,12 @@ func checkDefaultValue() error {
 		return fmt.Errorf("incr_sync.conflict_write_to in {none, db, sdk}")
 	}
 	if conf.Options.IncrSyncExecutorDupKeyStrategy == "" {
-		conf.Options.IncrSyncExecutorDupKeyStrategy = utils.VarIncrSyncExecutorDupKeyStrategyError
-	} else if conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyError &&
+		conf.Options.IncrSyncExecutorDupKeyStrategy = utils.VarIncrSyncExecutorDupKeyStrategyIgnore
+	} else if conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyIgnore &&
+		conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyError &&
 		conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry &&
 		conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategySkip {
-		return fmt.Errorf("incr_sync.executor.dup_key_strategy in {error, delete_and_retry, skip}")
+		return fmt.Errorf("incr_sync.executor.dup_key_strategy in {ignore, error, delete_and_retry, skip}")
 	}
 	if err := parseDupKeySkipRules(); err != nil {
 		return err
@@ -331,7 +332,7 @@ func parseDupKeySkipRules() error {
 			continue
 		}
 
-		parts := strings.Split(rule, ":")
+		parts := strings.SplitN(rule, ":", 2)
 		if len(parts) != 2 {
 			return fmt.Errorf("incr_sync.executor.dup_key_skip_rules should be ns:index1,index2; got [%s]", rule)
 		}

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -298,7 +298,14 @@ func checkDefaultValue() error {
 		conf.Options.IncrSyncConflictWriteTo != utils.VarIncrSyncConflictWriteToSdk {
 		return fmt.Errorf("incr_sync.conflict_write_to in {none, db, sdk}")
 	}
-	if err := parseSkipDupKeyOnInsertRules(); err != nil {
+	if conf.Options.IncrSyncExecutorDupKeyStrategy == "" {
+		conf.Options.IncrSyncExecutorDupKeyStrategy = utils.VarIncrSyncExecutorDupKeyStrategyError
+	} else if conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyError &&
+		conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry &&
+		conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategySkip {
+		return fmt.Errorf("incr_sync.executor.dup_key_strategy in {error, delete_and_retry, skip}")
+	}
+	if err := parseDupKeySkipRules(); err != nil {
 		return err
 	}
 	if conf.Options.IncrSyncReaderBufferTime <= 0 {
@@ -316,9 +323,9 @@ func checkDefaultValue() error {
 	return nil
 }
 
-func parseSkipDupKeyOnInsertRules() error {
+func parseDupKeySkipRules() error {
 	ruleMap := make(map[string]map[string]struct{})
-	for _, rule := range conf.Options.IncrSyncExecutorSkipDupKeyOnInsertRules {
+	for _, rule := range conf.Options.IncrSyncExecutorDupKeySkipRules {
 		rule = strings.TrimSpace(rule)
 		if rule == "" {
 			continue
@@ -326,17 +333,17 @@ func parseSkipDupKeyOnInsertRules() error {
 
 		parts := strings.Split(rule, ":")
 		if len(parts) != 2 {
-			return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules should be ns:index1,index2; got [%s]", rule)
+			return fmt.Errorf("incr_sync.executor.dup_key_skip_rules should be ns:index1,index2; got [%s]", rule)
 		}
 
 		ns := strings.TrimSpace(parts[0])
 		if ns == "" || !strings.Contains(ns, ".") {
-			return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules namespace should be db.collection; got [%s]", rule)
+			return fmt.Errorf("incr_sync.executor.dup_key_skip_rules namespace should be db.collection; got [%s]", rule)
 		}
 
 		indexes := strings.Split(parts[1], ",")
 		if len(indexes) == 0 {
-			return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules index list is empty for [%s]", ns)
+			return fmt.Errorf("incr_sync.executor.dup_key_skip_rules index list is empty for [%s]", ns)
 		}
 
 		if _, ok := ruleMap[ns]; !ok {
@@ -345,17 +352,17 @@ func parseSkipDupKeyOnInsertRules() error {
 		for _, index := range indexes {
 			index = strings.TrimSpace(index)
 			if index == "" {
-				return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules contains empty index for [%s]", ns)
+				return fmt.Errorf("incr_sync.executor.dup_key_skip_rules contains empty index for [%s]", ns)
 			}
 			ruleMap[ns][index] = struct{}{}
 		}
 	}
 
-	if conf.Options.IncrSyncExecutorSkipDupKeyOnInsert && len(ruleMap) == 0 {
-		return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules must be set when incr_sync.executor.skip_dup_key_on_insert is true")
+	if conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategySkip && len(ruleMap) == 0 {
+		return fmt.Errorf("incr_sync.executor.dup_key_skip_rules must be set when incr_sync.executor.dup_key_strategy is skip")
 	}
 
-	conf.Options.IncrSyncExecutorSkipDupKeyOnInsertRuleMap = ruleMap
+	conf.Options.IncrSyncExecutorDupKeySkipRulesMap = ruleMap
 	return nil
 }
 

--- a/cmd/collector/sanitize.go
+++ b/cmd/collector/sanitize.go
@@ -298,6 +298,9 @@ func checkDefaultValue() error {
 		conf.Options.IncrSyncConflictWriteTo != utils.VarIncrSyncConflictWriteToSdk {
 		return fmt.Errorf("incr_sync.conflict_write_to in {none, db, sdk}")
 	}
+	if err := parseSkipDupKeyOnInsertRules(); err != nil {
+		return err
+	}
 	if conf.Options.IncrSyncReaderBufferTime <= 0 {
 		conf.Options.IncrSyncReaderBufferTime = 1
 	}
@@ -310,6 +313,49 @@ func checkDefaultValue() error {
 	filter.NsShouldBeIgnore[utils.AppDatabase+"."] = true
 	filter.NsShouldBeIgnore[utils.APPConflictDatabase+"."] = true
 
+	return nil
+}
+
+func parseSkipDupKeyOnInsertRules() error {
+	ruleMap := make(map[string]map[string]struct{})
+	for _, rule := range conf.Options.IncrSyncExecutorSkipDupKeyOnInsertRules {
+		rule = strings.TrimSpace(rule)
+		if rule == "" {
+			continue
+		}
+
+		parts := strings.Split(rule, ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules should be ns:index1,index2; got [%s]", rule)
+		}
+
+		ns := strings.TrimSpace(parts[0])
+		if ns == "" || !strings.Contains(ns, ".") {
+			return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules namespace should be db.collection; got [%s]", rule)
+		}
+
+		indexes := strings.Split(parts[1], ",")
+		if len(indexes) == 0 {
+			return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules index list is empty for [%s]", ns)
+		}
+
+		if _, ok := ruleMap[ns]; !ok {
+			ruleMap[ns] = make(map[string]struct{})
+		}
+		for _, index := range indexes {
+			index = strings.TrimSpace(index)
+			if index == "" {
+				return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules contains empty index for [%s]", ns)
+			}
+			ruleMap[ns][index] = struct{}{}
+		}
+	}
+
+	if conf.Options.IncrSyncExecutorSkipDupKeyOnInsert && len(ruleMap) == 0 {
+		return fmt.Errorf("incr_sync.executor.skip_dup_key_on_insert.rules must be set when incr_sync.executor.skip_dup_key_on_insert is true")
+	}
+
+	conf.Options.IncrSyncExecutorSkipDupKeyOnInsertRuleMap = ruleMap
 	return nil
 }
 

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -76,25 +76,27 @@ type Configuration struct {
 	FullSyncDoNotShardDest               bool   `config:"full_sync.do_not_shard_destination"` // add v2.8.6
 
 	// 3. incr sync
-	IncrSyncMongoFetchMethod               string   `config:"incr_sync.mongo_fetch_method"`
-	IncrSyncChangeStreamWatchFullDocument  bool     `config:"incr_sync.change_stream.watch_full_document"`
-	IncrSyncReaderFetchBatchSize           int      `config:"incr_sync.reader.fetch_batch_size"`
-	IncrSyncOplogGIDS                      []string `config:"incr_sync.oplog.gids"`
-	IncrSyncShardKey                       string   `config:"incr_sync.shard_key"`
-	IncrSyncShardByObjectIdWhiteList       []string `config:"incr_sync.shard_by_object_id_whitelist"`
-	IncrSyncWorker                         int      `config:"incr_sync.worker"`
-	IncrSyncTunnelWriteThread              int      `config:"incr_sync.tunnel.write_thread"` // add v2.4.21
-	IncrSyncTargetDelay                    int64    `config:"incr_sync.target_delay"`
-	IncrSyncWorkerBatchQueueSize           uint64   `config:"incr_sync.worker.batch_queue_size"`
-	IncrSyncAdaptiveBatchingMaxSize        int      `config:"incr_sync.adaptive.batching_max_size"`
-	IncrSyncFetcherBufferCapacity          int      `config:"incr_sync.fetcher.buffer_capacity"`
-	IncrSyncFetcherBufferSizeThresholdInKB int      `config:"incr_sync.fetcher.buffer_size_threshold_in_kb"` // add v2.8.6
-	IncrSyncExecutorUpsert                 bool     `config:"incr_sync.executor.upsert"`
-	IncrSyncExecutorInsertOnDupUpdate      bool     `config:"incr_sync.executor.insert_on_dup_update"`
-	IncrSyncExecutorDeleteOnNonIdDupKey    bool     `config:"incr_sync.executor.delete_on_non_id_dup_key"` // add v2.8.9
-	IncrSyncConflictWriteTo                string   `config:"incr_sync.conflict_write_to"`                 // remove "sdk" option since v2.4.21
-	IncrSyncExecutorMajorityEnable         bool     `config:"incr_sync.executor.majority_enable"`
-	IncrSyncBypassDocumentValidation       bool     `config:"incr_sync.executor.bypass_document_validation"` // add v2.8.7
+	IncrSyncMongoFetchMethod                string   `config:"incr_sync.mongo_fetch_method"`
+	IncrSyncChangeStreamWatchFullDocument   bool     `config:"incr_sync.change_stream.watch_full_document"`
+	IncrSyncReaderFetchBatchSize            int      `config:"incr_sync.reader.fetch_batch_size"`
+	IncrSyncOplogGIDS                       []string `config:"incr_sync.oplog.gids"`
+	IncrSyncShardKey                        string   `config:"incr_sync.shard_key"`
+	IncrSyncShardByObjectIdWhiteList        []string `config:"incr_sync.shard_by_object_id_whitelist"`
+	IncrSyncWorker                          int      `config:"incr_sync.worker"`
+	IncrSyncTunnelWriteThread               int      `config:"incr_sync.tunnel.write_thread"` // add v2.4.21
+	IncrSyncTargetDelay                     int64    `config:"incr_sync.target_delay"`
+	IncrSyncWorkerBatchQueueSize            uint64   `config:"incr_sync.worker.batch_queue_size"`
+	IncrSyncAdaptiveBatchingMaxSize         int      `config:"incr_sync.adaptive.batching_max_size"`
+	IncrSyncFetcherBufferCapacity           int      `config:"incr_sync.fetcher.buffer_capacity"`
+	IncrSyncFetcherBufferSizeThresholdInKB  int      `config:"incr_sync.fetcher.buffer_size_threshold_in_kb"` // add v2.8.6
+	IncrSyncExecutorUpsert                  bool     `config:"incr_sync.executor.upsert"`
+	IncrSyncExecutorInsertOnDupUpdate       bool     `config:"incr_sync.executor.insert_on_dup_update"`
+	IncrSyncExecutorSkipDupKeyOnInsert      bool     `config:"incr_sync.executor.skip_dup_key_on_insert"`
+	IncrSyncExecutorSkipDupKeyOnInsertRules []string `config:"incr_sync.executor.skip_dup_key_on_insert.rules"`
+	IncrSyncExecutorDeleteOnNonIdDupKey     bool     `config:"incr_sync.executor.delete_on_non_id_dup_key"` // add v2.8.9
+	IncrSyncConflictWriteTo                 string   `config:"incr_sync.conflict_write_to"`                 // remove "sdk" option since v2.4.21
+	IncrSyncExecutorMajorityEnable          bool     `config:"incr_sync.executor.majority_enable"`
+	IncrSyncBypassDocumentValidation        bool     `config:"incr_sync.executor.bypass_document_validation"` // add v2.8.7
 
 	/*---------------------------------------------------------*/
 	// inner variables, not open to user
@@ -112,9 +114,10 @@ type Configuration struct {
 
 	/*---------------------------------------------------------*/
 	// generated variables
-	Version         string // version
-	SourceDBVersion string
-	TargetDBVersion string
+	Version                                   string // version
+	SourceDBVersion                           string
+	TargetDBVersion                           string
+	IncrSyncExecutorSkipDupKeyOnInsertRuleMap map[string]map[string]struct{}
 
 	/*---------------------------------------------------------*/
 	// deprecate variables

--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -91,10 +91,9 @@ type Configuration struct {
 	IncrSyncFetcherBufferSizeThresholdInKB  int      `config:"incr_sync.fetcher.buffer_size_threshold_in_kb"` // add v2.8.6
 	IncrSyncExecutorUpsert                  bool     `config:"incr_sync.executor.upsert"`
 	IncrSyncExecutorInsertOnDupUpdate       bool     `config:"incr_sync.executor.insert_on_dup_update"`
-	IncrSyncExecutorSkipDupKeyOnInsert      bool     `config:"incr_sync.executor.skip_dup_key_on_insert"`
-	IncrSyncExecutorSkipDupKeyOnInsertRules []string `config:"incr_sync.executor.skip_dup_key_on_insert.rules"`
-	IncrSyncExecutorDeleteOnNonIdDupKey     bool     `config:"incr_sync.executor.delete_on_non_id_dup_key"` // add v2.8.9
-	IncrSyncConflictWriteTo                 string   `config:"incr_sync.conflict_write_to"`                 // remove "sdk" option since v2.4.21
+	IncrSyncExecutorDupKeyStrategy          string   `config:"incr_sync.executor.dup_key_strategy"`   // add v2.8.9
+	IncrSyncExecutorDupKeySkipRules         []string `config:"incr_sync.executor.dup_key_skip_rules"` // add v2.8.9
+	IncrSyncConflictWriteTo                 string   `config:"incr_sync.conflict_write_to"`           // remove "sdk" option since v2.4.21
 	IncrSyncExecutorMajorityEnable          bool     `config:"incr_sync.executor.majority_enable"`
 	IncrSyncBypassDocumentValidation        bool     `config:"incr_sync.executor.bypass_document_validation"` // add v2.8.7
 
@@ -114,10 +113,10 @@ type Configuration struct {
 
 	/*---------------------------------------------------------*/
 	// generated variables
-	Version                                   string // version
-	SourceDBVersion                           string
-	TargetDBVersion                           string
-	IncrSyncExecutorSkipDupKeyOnInsertRuleMap map[string]map[string]struct{}
+	Version                            string // version
+	SourceDBVersion                    string
+	TargetDBVersion                    string
+	IncrSyncExecutorDupKeySkipRulesMap map[string]map[string]struct{}
 
 	/*---------------------------------------------------------*/
 	// deprecate variables

--- a/common/define.go
+++ b/common/define.go
@@ -58,6 +58,11 @@ const (
 	VarIncrSyncConflictWriteToDb   = "db"
 	VarIncrSyncConflictWriteToSdk  = "sdk"
 
+	// incr_sync.executor.dup_key_strategy
+	VarIncrSyncExecutorDupKeyStrategyError          = "error"
+	VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry = "delete_and_retry"
+	VarIncrSyncExecutorDupKeyStrategySkip           = "skip"
+
 	// checkpoint.storage.db
 	VarCheckpointStorageDbReplicaDefault  = "mongoshake"
 	VarCheckpointStorageDbShardingDefault = "admin"

--- a/common/define.go
+++ b/common/define.go
@@ -59,6 +59,7 @@ const (
 	VarIncrSyncConflictWriteToSdk  = "sdk"
 
 	// incr_sync.executor.dup_key_strategy
+	VarIncrSyncExecutorDupKeyStrategyIgnore         = "ignore"
 	VarIncrSyncExecutorDupKeyStrategyError          = "error"
 	VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry = "delete_and_retry"
 	VarIncrSyncExecutorDupKeyStrategySkip           = "skip"

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -370,18 +370,22 @@ incr_sync.executor.upsert = false
 # oplog changes to Update while Insert found duplicated key (_id or unique-index)
 # 如果_id存在在目的库，是否将insert语句修改为update语句。
 incr_sync.executor.insert_on_dup_update = false
-# skip insert oplog when insert_on_dup_update still fails with duplicate key.
-# rules format: db.collection:index1,index2;db.collection:* . Empty means disabled.
-# 当insert_on_dup_update二次兜底仍因重复键失败时，按规则跳过该insert oplog。
-# 规则格式：db.collection:index1,index2;db.collection:* 。为空表示不启用。
-incr_sync.executor.skip_dup_key_on_insert = false
-incr_sync.executor.skip_dup_key_on_insert.rules =
-# when insert_on_dup_update upsert still hits a non-_id unique index duplicate key error,
-# delete the conflicting document and retry. This resolves blocking caused by business unique
-# index conflicts, but may delete target-side data. Only enable when source is authoritative.
-# 当 insert_on_dup_update 的 upsert 仍因非 _id 唯一索引冲突而失败时，删除冲突文档并重试。
-# 仅在「以源端为准」的单向同步场景下启用；双端有流量时请勿开启，以免误删目标端数据。
-incr_sync.executor.delete_on_non_id_dup_key = false
+# duplicate key strategy when insert_on_dup_update upsert still hits a duplicate key error.
+# options:
+#   error            keep original behavior, block and return error.
+#   delete_and_retry source is authoritative: delete conflicting target document and retry.
+#   skip             target is authoritative: skip matched oplogs and record them as duplicated.
+# 当 insert_on_dup_update 的 upsert 仍因重复键冲突失败时的处理策略。
+# 可选项：
+#   error            默认，保持原有行为，阻塞报错。
+#   delete_and_retry 源端为准，删除目标端冲突文档后重试；双端有流量时请勿开启。
+#   skip             目标端为准，按白名单跳过 oplog 并记录重复日志。
+incr_sync.executor.dup_key_strategy = error
+# skip rules used only when dup_key_strategy = skip.
+# format: db.collection:index1,index2;db.collection:* . Empty means no skip rule.
+# 仅当 dup_key_strategy = skip 时生效。
+# 规则格式：db.collection:index1,index2;db.collection:* 。为空表示不启用跳过规则。
+incr_sync.executor.dup_key_skip_rules =
 # options:db,none
 # db. write duplicated logs to mongoshake_conflict
 # 如果写入存在冲突，记录冲突的文档。选项：db, none

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -370,17 +370,19 @@ incr_sync.executor.upsert = false
 # oplog changes to Update while Insert found duplicated key (_id or unique-index)
 # 如果_id存在在目的库，是否将insert语句修改为update语句。
 incr_sync.executor.insert_on_dup_update = false
-# duplicate key strategy when insert_on_dup_update upsert still hits a duplicate key error.
+# duplicate key strategy when insert/upsert hits a duplicate key error.
 # options:
-#   error            keep original behavior, block and return error.
+#   ignore           default, keep historical behavior: record duplicated oplogs and continue.
+#   error            strict mode: block and return error.
 #   delete_and_retry source is authoritative: delete conflicting target document and retry.
 #   skip             target is authoritative: skip matched oplogs and record them as duplicated.
-# 当 insert_on_dup_update 的 upsert 仍因重复键冲突失败时的处理策略。
+# 当 insert/upsert 遇到重复键冲突时的处理策略。
 # 可选项：
-#   error            默认，保持原有行为，阻塞报错。
+#   ignore           默认，保持历史行为：记录重复 oplog 后继续。
+#   error            严格模式，阻塞报错。
 #   delete_and_retry 源端为准，删除目标端冲突文档后重试；双端有流量时请勿开启。
 #   skip             目标端为准，按白名单跳过 oplog 并记录重复日志。
-incr_sync.executor.dup_key_strategy = error
+incr_sync.executor.dup_key_strategy = ignore
 # skip rules used only when dup_key_strategy = skip.
 # format: db.collection:index1,index2;db.collection:* . Empty means no skip rule.
 # 仅当 dup_key_strategy = skip 时生效。

--- a/conf/collector.conf
+++ b/conf/collector.conf
@@ -370,6 +370,12 @@ incr_sync.executor.upsert = false
 # oplog changes to Update while Insert found duplicated key (_id or unique-index)
 # 如果_id存在在目的库，是否将insert语句修改为update语句。
 incr_sync.executor.insert_on_dup_update = false
+# skip insert oplog when insert_on_dup_update still fails with duplicate key.
+# rules format: db.collection:index1,index2;db.collection:* . Empty means disabled.
+# 当insert_on_dup_update二次兜底仍因重复键失败时，按规则跳过该insert oplog。
+# 规则格式：db.collection:index1,index2;db.collection:* 。为空表示不启用。
+incr_sync.executor.skip_dup_key_on_insert = false
+incr_sync.executor.skip_dup_key_on_insert.rules =
 # when insert_on_dup_update upsert still hits a non-_id unique index duplicate key error,
 # delete the conflicting document and retry. This resolves blocking caused by business unique
 # index conflicts, but may delete target-side data. Only enable when source is authoritative.

--- a/docs/fix-e11000-dup-key-blocking-incr-sync.md
+++ b/docs/fix-e11000-dup-key-blocking-incr-sync.md
@@ -19,9 +19,17 @@
 
 ## 修复方案
 
-**核心思路：opt-in 删除冲突文档 + 重试 upsert**
+**核心思路：通过统一策略配置处理重复键冲突**
 
-新增配置项 `incr_sync.executor.delete_on_non_id_dup_key`（默认 false），开启后：
+新增配置项 `incr_sync.executor.dup_key_strategy`（默认 `error`），可选值：
+
+- `error`：保持原有行为，阻塞报错。
+- `delete_and_retry`：源端为准，删除冲突文档并重试 upsert。
+- `skip`：目标端为准，按 `incr_sync.executor.dup_key_skip_rules` 白名单跳过并记录重复 oplog。
+
+`skip` 策略需要配置白名单规则，格式为 `db.collection:index1,index2;db.collection:*`，用于限定可跳过的 namespace 和 index，避免扩大影响范围。
+
+当配置为 `delete_and_retry` 时：
 
 1. **解析 E11000 错误的 `dup key: { ... }` 部分**，提取冲突字段名（如 `account`、`a, b`）
 2. **判断**：如果是 `_id_` 索引，走已有逻辑；如果是非 `_id` 唯一索引，进入新逻辑
@@ -52,7 +60,7 @@ E11000 duplicate key error collection: db.coll index: a_1_b_1 dup key: { a: "x",
 
 | 文件 | 改动 |
 |------|------|
-| `collector/configure/configure.go` | 新增 `IncrSyncExecutorDeleteOnNonIdDupKey` 配置字段 |
+| `collector/configure/configure.go` | 新增 `IncrSyncExecutorDupKeyStrategy` 配置字段 |
 | `conf/collector.conf` | 新增配置项及说明 |
 | `executor/dup_key_resolver.go` | 新增：`parseDupKeyIndexName()`、`parseDupKeyFields()`、`resolveConflictFilter()`、`deleteConflictAndRetry()` |
 | `executor/db_writer_single.go` | 修改 `doUpdateOnInsert()` 的 upsert 分支，配置开启时调用 resolver |
@@ -62,9 +70,14 @@ E11000 duplicate key error collection: db.coll index: a_1_b_1 dup key: { a: "x",
 ## 配置说明
 
 ```ini
-# 当 insert_on_dup_update 的 upsert 仍因非 _id 唯一索引冲突而失败时，
-# 删除冲突文档并重试。仅在「以源端为准」的单向同步场景下启用。
-incr_sync.executor.delete_on_non_id_dup_key = false
+# 当 insert_on_dup_update 的 upsert 仍因重复键冲突失败时的处理策略。
+# error            默认，保持原有行为，阻塞报错。
+# delete_and_retry 源端为准，删除目标端冲突文档后重试；双端有流量时请勿开启。
+# skip             目标端为准，按白名单跳过 oplog 并记录重复日志。
+incr_sync.executor.dup_key_strategy = error
+# 仅当 dup_key_strategy = skip 时生效。
+# 规则格式：db.collection:index1,index2;db.collection:*
+incr_sync.executor.dup_key_skip_rules =
 ```
 
 ## 验证

--- a/docs/fix-e11000-dup-key-blocking-incr-sync.md
+++ b/docs/fix-e11000-dup-key-blocking-incr-sync.md
@@ -21,9 +21,10 @@
 
 **核心思路：通过统一策略配置处理重复键冲突**
 
-新增配置项 `incr_sync.executor.dup_key_strategy`（默认 `error`），可选值：
+新增配置项 `incr_sync.executor.dup_key_strategy`（默认 `ignore`），可选值：
 
-- `error`：保持原有行为，阻塞报错。
+- `ignore`：保持历史行为，记录重复 oplog 后继续。
+- `error`：严格模式，阻塞报错。
 - `delete_and_retry`：源端为准，删除冲突文档并重试 upsert。
 - `skip`：目标端为准，按 `incr_sync.executor.dup_key_skip_rules` 白名单跳过并记录重复 oplog。
 
@@ -71,10 +72,11 @@ E11000 duplicate key error collection: db.coll index: a_1_b_1 dup key: { a: "x",
 
 ```ini
 # 当 insert_on_dup_update 的 upsert 仍因重复键冲突失败时的处理策略。
-# error            默认，保持原有行为，阻塞报错。
+# ignore           默认，保持历史行为：记录重复 oplog 后继续。
+# error            严格模式，阻塞报错。
 # delete_and_retry 源端为准，删除目标端冲突文档后重试；双端有流量时请勿开启。
 # skip             目标端为准，按白名单跳过 oplog 并记录重复日志。
-incr_sync.executor.dup_key_strategy = error
+incr_sync.executor.dup_key_strategy = ignore
 # 仅当 dup_key_strategy = skip 时生效。
 # 规则格式：db.collection:index1,index2;db.collection:*
 incr_sync.executor.dup_key_skip_rules =

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -66,16 +67,48 @@ func (bw *BulkWriter) doInsert(database, collection string, metadata bson.E, opl
 		}
 
 		if utils.DuplicateKey(err) {
-			RecordDuplicatedOplog(bw.conn, collection, oplogs)
 			// update on duplicated key occur
 			if dupUpdate {
+				RecordDuplicatedOplog(bw.conn, collection, oplogs)
 				l.Logger.Infof("Duplicated document found. reinsert or update to [%s] [%s]", database, collection)
 				return bw.doUpdateOnInsert(database, collection, metadata, oplogs, conf.Options.IncrSyncExecutorUpsert)
 			}
-			return nil
+			switch conf.Options.IncrSyncExecutorDupKeyStrategy {
+			case "", utils.VarIncrSyncExecutorDupKeyStrategyIgnore:
+				return handleDupKeyOnInsert(bw.conn, database, collection, oplogs, err, "bulk_writer::doInsert")
+			case utils.VarIncrSyncExecutorDupKeyStrategySkip:
+				return bw.handleBulkInsertDupKeySkip(database, collection, oplogs, err)
+			default:
+				return err
+			}
 		}
 		return err
 	}
+	return nil
+}
+
+func (bw *BulkWriter) handleBulkInsertDupKeySkip(database, collection string, oplogs []*OplogRecord, err error) error {
+	bulkErr, ok := err.(mongo.BulkWriteException)
+	if !ok {
+		return err
+	}
+	for _, writeErr := range bulkErr.WriteErrors {
+		if !writeErr.HasErrorCode(11000) {
+			return err
+		}
+		if writeErr.Index < 0 || writeErr.Index >= len(oplogs) {
+			return err
+		}
+		indexName := parseDupKeyIndexName(fmt.Errorf("%s", writeErr.Message))
+		if indexName != "_id_" && !shouldSkipDupKeyIndex(database, collection, indexName) {
+			return err
+		}
+	}
+	for _, writeErr := range bulkErr.WriteErrors {
+		RecordDuplicatedOplog(bw.conn, collection, []*OplogRecord{oplogs[writeErr.Index]})
+	}
+	l.Logger.Warnf("bulk_writer::doInsert duplicated oplogs skipped, ns[%s.%s], err[%v]",
+		database, collection, err)
 	return nil
 }
 
@@ -109,6 +142,10 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 		}
 
 		l.Logger.Debugf("bulk_writer: updateOnInsert %v", log.original.partialLog)
+	}
+
+	if len(models) == 0 {
+		return nil
 	}
 
 	opts := options.BulkWrite()

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -27,6 +27,7 @@ type BulkWriter struct {
 func (bw *BulkWriter) doInsert(database, collection string, metadata bson.E, oplogs []*OplogRecord, dupUpdate bool) error {
 
 	var models []mongo.WriteModel
+	var modelOplogs []*OplogRecord
 	for _, log := range oplogs {
 		if log.original.partialLog.Operation == "i" &&
 			strings.HasSuffix(log.original.partialLog.Namespace, utils.VarSystemViewsCollection) {
@@ -40,6 +41,7 @@ func (bw *BulkWriter) doInsert(database, collection string, metadata bson.E, opl
 			}
 		} else {
 			models = append(models, mongo.NewInsertOneModel().SetDocument(log.original.partialLog.Object))
+			modelOplogs = append(modelOplogs, log)
 			l.Logger.Debugf("bulk_writer: insert org_oplog:%v insert_doc:%v",
 				log.original.partialLog, log.original.partialLog.Object)
 		}
@@ -77,7 +79,7 @@ func (bw *BulkWriter) doInsert(database, collection string, metadata bson.E, opl
 			case "", utils.VarIncrSyncExecutorDupKeyStrategyIgnore:
 				return handleDupKeyOnInsert(bw.conn, database, collection, oplogs, err, "bulk_writer::doInsert")
 			case utils.VarIncrSyncExecutorDupKeyStrategySkip:
-				return bw.handleBulkInsertDupKeySkip(database, collection, oplogs, err)
+				return bw.handleBulkInsertDupKeySkip(database, collection, modelOplogs, err)
 			default:
 				return err
 			}
@@ -88,8 +90,8 @@ func (bw *BulkWriter) doInsert(database, collection string, metadata bson.E, opl
 }
 
 func (bw *BulkWriter) handleBulkInsertDupKeySkip(database, collection string, oplogs []*OplogRecord, err error) error {
-	bulkErr, ok := err.(mongo.BulkWriteException)
-	if !ok {
+	var bulkErr mongo.BulkWriteException
+	if !errors.As(err, &bulkErr) {
 		return err
 	}
 	for _, writeErr := range bulkErr.WriteErrors {

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -125,6 +125,9 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 		if utils.DuplicateKey(err) {
 			// create single writer to write one by one
 			sw := NewDbWriter(bw.conn, bson.E{}, false, bw.fullFinishTs)
+			if index < 0 || index >= len(oplogs) {
+				return err
+			}
 			return sw.doUpdateOnInsert(database, collection, metadata, oplogs[index:], upsert)
 		}
 

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -94,6 +94,9 @@ func (bw *BulkWriter) handleBulkInsertDupKeySkip(database, collection string, op
 	if !errors.As(err, &bulkErr) {
 		return err
 	}
+	if bulkErr.WriteConcernError != nil {
+		return err
+	}
 	for _, writeErr := range bulkErr.WriteErrors {
 		if !writeErr.HasErrorCode(11000) {
 			return err
@@ -116,6 +119,7 @@ func (bw *BulkWriter) handleBulkInsertDupKeySkip(database, collection string, op
 
 func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bson.E, oplogs []*OplogRecord, upsert bool) error {
 	var models []mongo.WriteModel
+	var modelOplogs []*OplogRecord
 
 	for _, log := range oplogs {
 		newObject := log.original.partialLog.Object
@@ -124,6 +128,7 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 			models = append(models, mongo.NewUpdateOneModel().
 				SetFilter(log.original.partialLog.DocumentKey).
 				SetUpdate(bson.D{{"$set", newObject}}).SetUpsert(true))
+			modelOplogs = append(modelOplogs, log)
 		} else {
 			// if upsert {
 			//	l.Logger.Warnf("doUpdateOnInsert runs upsert but lack documentKey: %v", log.original.partialLog)
@@ -138,6 +143,7 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 					model.SetUpsert(true)
 				}
 				models = append(models, model)
+				modelOplogs = append(modelOplogs, log)
 			} else {
 				l.Logger.Warnf("Insert on duplicated update _id look up failed. %v", log)
 			}
@@ -164,10 +170,10 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 		if utils.DuplicateKey(err) {
 			// create single writer to write one by one
 			sw := NewDbWriter(bw.conn, bson.E{}, false, bw.fullFinishTs)
-			if index < 0 || index >= len(oplogs) {
+			if index < 0 || index >= len(modelOplogs) {
 				return err
 			}
-			return sw.doUpdateOnInsert(database, collection, metadata, oplogs[index:], upsert)
+			return sw.doUpdateOnInsert(database, collection, metadata, modelOplogs[index:], upsert)
 		}
 
 		// error can be ignored

--- a/executor/db_writer_command.go
+++ b/executor/db_writer_command.go
@@ -114,11 +114,19 @@ func (cw *CommandWriter) doUpdateOnInsert(database, collection string, metadata 
 	}
 
 	if utils.DuplicateKey(err) {
-		if conf.Options.IncrSyncExecutorDeleteOnNonIdDupKey {
+		switch conf.Options.IncrSyncExecutorDupKeyStrategy {
+		case utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry:
 			return cw.retryUpdateOnInsertIndividually(database, collection, metadata, oplogs, upsert)
+		case utils.VarIncrSyncExecutorDupKeyStrategySkip:
+			if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
+				RecordDuplicatedOplog(cw.conn, collection, oplogs)
+				l.Logger.Warnf("skip duplicated update_on_insert oplogs, ns[%s.%s], index[%s], err[%v]",
+					database, collection, indexName, err)
+				return nil
+			}
 		}
-		l.Logger.Infof("Duplicated document found on doUpdateOnInsert [%s] [%s]", database, collection)
-		return nil
+		l.Logger.Errorf("Duplicated document found on doUpdateOnInsert [%s] [%s]: %v", database, collection, err)
+		return err
 	}
 	return err
 }

--- a/executor/db_writer_command.go
+++ b/executor/db_writer_command.go
@@ -199,18 +199,24 @@ func (cw *CommandWriter) retryUpdateOnInsertIndividually(database, collection st
 			return retryErr
 		}
 
-		switch conf.Options.IncrSyncExecutorDupKeyStrategy {
-		case utils.VarIncrSyncExecutorDupKeyStrategySkip:
+		indexName := parseDupKeyIndexName(retryErr)
+		if conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategySkip {
+			if indexName == "_id_" {
+				RecordDuplicatedOplog(cw.conn, collection, []*OplogRecord{log})
+				l.Logger.Infof("Duplicated document found on doUpdateOnInsert [%s] [%s] _id[%v], treated as already applied",
+					database, collection, id)
+				continue
+			}
 			if handleErr := handleDupKeyOnInsert(cw.conn, database, collection, []*OplogRecord{log}, retryErr,
 				"command_writer::retryUpdateOnInsertIndividually"); handleErr != nil {
 				return handleErr
 			}
 			continue
-		case utils.VarIncrSyncExecutorDupKeyStrategyError:
+		}
+		if conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategyError {
 			return retryErr
 		}
 
-		indexName := parseDupKeyIndexName(retryErr)
 		if indexName == "_id_" {
 			RecordDuplicatedOplog(cw.conn, collection, []*OplogRecord{log})
 			l.Logger.Infof("Duplicated document found on doUpdateOnInsert [%s] [%s] _id[%v]",

--- a/executor/db_writer_command.go
+++ b/executor/db_writer_command.go
@@ -64,7 +64,13 @@ func (cw *CommandWriter) doInsert(database, collection string, metadata bson.E, 
 			l.Logger.Infof("Duplicated document found. reinsert or update to [%s.%s]", database, collection)
 			return cw.doUpdateOnInsert(database, collection, metadata, oplogs, conf.Options.IncrSyncExecutorUpsert)
 		}
-		return nil
+		if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
+			l.Logger.Warnf("skip duplicated insert oplogs, ns[%s.%s], index[%s], err[%v]",
+				database, collection, indexName, err)
+			return nil
+		}
+		l.Logger.Errorf("Duplicated document found on doInsert [%s.%s]: %v", database, collection, err)
+		return err
 	}
 	return err
 }

--- a/executor/db_writer_command.go
+++ b/executor/db_writer_command.go
@@ -58,21 +58,60 @@ func (cw *CommandWriter) doInsert(database, collection string, metadata bson.E, 
 	}
 
 	if utils.DuplicateKey(err) {
-		RecordDuplicatedOplog(cw.conn, collection, oplogs)
 		// update on duplicated key occur
 		if dupUpdate {
+			RecordDuplicatedOplog(cw.conn, collection, oplogs)
 			l.Logger.Infof("Duplicated document found. reinsert or update to [%s.%s]", database, collection)
 			return cw.doUpdateOnInsert(database, collection, metadata, oplogs, conf.Options.IncrSyncExecutorUpsert)
 		}
-		if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
-			l.Logger.Warnf("skip duplicated insert oplogs, ns[%s.%s], index[%s], err[%v]",
-				database, collection, indexName, err)
-			return nil
+		if conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategySkip {
+			return cw.retryInsertIndividually(database, collection, metadata, oplogs)
 		}
-		l.Logger.Errorf("Duplicated document found on doInsert [%s.%s]: %v", database, collection, err)
-		return err
+		return handleDupKeyOnInsert(cw.conn, database, collection, oplogs, err, "command_writer::doInsert")
 	}
 	return err
+}
+
+func (cw *CommandWriter) retryInsertIndividually(database, collection string, metadata bson.E,
+	oplogs []*OplogRecord) error {
+	for _, log := range oplogs {
+		retryErr := cw.runSingleInsertCmd(database, collection, metadata, log.original.partialLog.Object)
+		if retryErr == nil {
+			continue
+		}
+		if !utils.DuplicateKey(retryErr) {
+			return retryErr
+		}
+		indexName := parseDupKeyIndexName(retryErr)
+		if indexName == "_id_" {
+			RecordDuplicatedOplog(cw.conn, collection, []*OplogRecord{log})
+			l.Logger.Infof("Duplicated document found on doInsert [%s] [%s] _id, treated as already applied",
+				database, collection)
+			continue
+		}
+		if handleErr := handleDupKeyOnInsert(cw.conn, database, collection, []*OplogRecord{log}, retryErr,
+			"command_writer::retryInsertIndividually"); handleErr != nil {
+			return handleErr
+		}
+	}
+	return nil
+}
+
+func (cw *CommandWriter) runSingleInsertCmd(database, collection string, metadata bson.E, doc bson.D) error {
+	insertCmd := bson.D{
+		{"insert", collection},
+		{"documents", []bson.D{doc}},
+		{"ordered", ExecuteOrdered},
+	}
+	if conf.Options.IncrSyncBypassDocumentValidation {
+		insertCmd = append(insertCmd, bson.E{Key: "bypassDocumentValidation", Value: true})
+	} else {
+		insertCmd = append(insertCmd, bson.E{Key: "bypassDocumentValidation", Value: false})
+	}
+	if metadata.Key == "g" {
+		insertCmd = append(insertCmd, metadata)
+	}
+	return cw.conn.Client.Database(database).RunCommand(context.Background(), insertCmd).Err()
 }
 
 func (cw *CommandWriter) doUpdateOnInsert(database, collection string, metadata bson.E, oplogs []*OplogRecord,
@@ -92,6 +131,10 @@ func (cw *CommandWriter) doUpdateOnInsert(database, collection string, metadata 
 			l.Logger.Warnf("Insert on duplicated update _id look up failed. %v", log)
 		}
 		l.Logger.Debugf("command_writer:: updateOnInsert %v", log.original.partialLog)
+	}
+
+	if len(updates) == 0 {
+		return nil
 	}
 
 	var err error
@@ -121,15 +164,13 @@ func (cw *CommandWriter) doUpdateOnInsert(database, collection string, metadata 
 
 	if utils.DuplicateKey(err) {
 		switch conf.Options.IncrSyncExecutorDupKeyStrategy {
-		case utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry:
+		case "", utils.VarIncrSyncExecutorDupKeyStrategyIgnore:
+			RecordDuplicatedOplog(cw.conn, collection, oplogs)
+			l.Logger.Infof("Duplicated document found on doUpdateOnInsert [%s] [%s], ignored", database, collection)
+			return nil
+		case utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry,
+			utils.VarIncrSyncExecutorDupKeyStrategySkip:
 			return cw.retryUpdateOnInsertIndividually(database, collection, metadata, oplogs, upsert)
-		case utils.VarIncrSyncExecutorDupKeyStrategySkip:
-			if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
-				RecordDuplicatedOplog(cw.conn, collection, oplogs)
-				l.Logger.Warnf("skip duplicated update_on_insert oplogs, ns[%s.%s], index[%s], err[%v]",
-					database, collection, indexName, err)
-				return nil
-			}
 		}
 		l.Logger.Errorf("Duplicated document found on doUpdateOnInsert [%s] [%s]: %v", database, collection, err)
 		return err
@@ -158,8 +199,20 @@ func (cw *CommandWriter) retryUpdateOnInsertIndividually(database, collection st
 			return retryErr
 		}
 
+		switch conf.Options.IncrSyncExecutorDupKeyStrategy {
+		case utils.VarIncrSyncExecutorDupKeyStrategySkip:
+			if handleErr := handleDupKeyOnInsert(cw.conn, database, collection, []*OplogRecord{log}, retryErr,
+				"command_writer::retryUpdateOnInsertIndividually"); handleErr != nil {
+				return handleErr
+			}
+			continue
+		case utils.VarIncrSyncExecutorDupKeyStrategyError:
+			return retryErr
+		}
+
 		indexName := parseDupKeyIndexName(retryErr)
 		if indexName == "_id_" {
+			RecordDuplicatedOplog(cw.conn, collection, []*OplogRecord{log})
 			l.Logger.Infof("Duplicated document found on doUpdateOnInsert [%s] [%s] _id[%v]",
 				database, collection, id)
 			continue

--- a/executor/db_writer_single.go
+++ b/executor/db_writer_single.go
@@ -171,6 +171,11 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 						continue
 					}
 				}
+				if conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategySkip &&
+					parseDupKeyIndexName(err) == "_id_" {
+					RecordDuplicatedOplog(sw.conn, collection, []*OplogRecord{oplogs[update.index]})
+					continue
+				}
 				if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
 					RecordDuplicatedOplog(sw.conn, collection, []*OplogRecord{oplogs[update.index]})
 					l.Logger.Warnf("skip duplicated insert after update_on_insert failed, ns[%s.%s], index[%s], id[%v], ts[%v], err[%v]",

--- a/executor/db_writer_single.go
+++ b/executor/db_writer_single.go
@@ -69,7 +69,19 @@ func (sw *SingleWriter) doInsert(database, collection string, metadata bson.E, o
 		if _, err := collectionHandle.InsertOne(context.Background(), log.original.partialLog.Object, opts); err != nil {
 
 			if utils.DuplicateKey(err) {
-				upserts = append(upserts, log)
+				if dupUpdate {
+					upserts = append(upserts, log)
+					continue
+				}
+				if conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategySkip &&
+					parseDupKeyIndexName(err) == "_id_" {
+					RecordDuplicatedOplog(sw.conn, collection, []*OplogRecord{log})
+					continue
+				}
+				if handleErr := handleDupKeyOnInsert(sw.conn, database, collection, []*OplogRecord{log}, err,
+					"single_writer::doInsert"); handleErr != nil {
+					return handleErr
+				}
 				continue
 			} else {
 				l.Logger.Errorf("insert data[%v] failed[%v]", log.original.partialLog.Object, err)
@@ -82,13 +94,8 @@ func (sw *SingleWriter) doInsert(database, collection string, metadata bson.E, o
 
 	if len(upserts) != 0 {
 		RecordDuplicatedOplog(sw.conn, collection, upserts)
-
-		// update on duplicated key occur
-		if dupUpdate {
-			l.Logger.Infof("Duplicated document found. reinsert or update to [%s] [%s]", database, collection)
-			return sw.doUpdateOnInsert(database, collection, metadata, upserts, conf.Options.IncrSyncExecutorUpsert)
-		}
-		return nil
+		l.Logger.Infof("Duplicated document found. reinsert or update to [%s] [%s]", database, collection)
+		return sw.doUpdateOnInsert(database, collection, metadata, upserts, conf.Options.IncrSyncExecutorUpsert)
 	}
 	return nil
 }
@@ -135,6 +142,11 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 
 				if utils.DuplicateKey(err) {
 					if utils.TimeStampToInt64(oplogs[update.index].original.partialLog.Timestamp) <= sw.fullFinishTs {
+						continue
+					}
+					if conf.Options.IncrSyncExecutorDupKeyStrategy == "" ||
+						conf.Options.IncrSyncExecutorDupKeyStrategy == utils.VarIncrSyncExecutorDupKeyStrategyIgnore {
+						RecordDuplicatedOplog(sw.conn, collection, []*OplogRecord{oplogs[update.index]})
 						continue
 					}
 

--- a/executor/db_writer_single.go
+++ b/executor/db_writer_single.go
@@ -159,6 +159,12 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 						continue
 					}
 				}
+				if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
+					RecordDuplicatedOplog(sw.conn, collection, []*OplogRecord{oplogs[update.index]})
+					l.Logger.Warnf("skip duplicated insert after update_on_insert failed, ns[%s.%s], index[%s], id[%v], ts[%v], err[%v]",
+						database, collection, indexName, update.id, oplogs[update.index].original.partialLog.Timestamp, err)
+					continue
+				}
 
 				l.Logger.Errorf("upsert _id[%v] with data[%v] failed[%v]", update.id, update.data, err)
 				return err

--- a/executor/db_writer_test.go
+++ b/executor/db_writer_test.go
@@ -2786,8 +2786,8 @@ func TestSingleWriterDeleteOnNonIdDupKey(t *testing.T) {
 		t.Skipf("skip integration test, cannot connect to MongoDB: %v", err)
 	}
 
-	conf.Options.IncrSyncExecutorDeleteOnNonIdDupKey = true
-	defer func() { conf.Options.IncrSyncExecutorDeleteOnNonIdDupKey = false }()
+	conf.Options.IncrSyncExecutorDupKeyStrategy = utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry
+	defer func() { conf.Options.IncrSyncExecutorDupKeyStrategy = utils.VarIncrSyncExecutorDupKeyStrategyError }()
 
 	_ = utils.InitialLogger("", "", "debug", true, 1)
 	writer := NewDbWriter(conn, bson.E{}, false, -1)
@@ -2831,7 +2831,7 @@ func TestSingleWriterDeleteOnNonIdDupKeyDisabled(t *testing.T) {
 		t.Skipf("skip integration test, cannot connect to MongoDB: %v", err)
 	}
 
-	conf.Options.IncrSyncExecutorDeleteOnNonIdDupKey = false
+	conf.Options.IncrSyncExecutorDupKeyStrategy = utils.VarIncrSyncExecutorDupKeyStrategyError
 	_ = utils.InitialLogger("", "", "debug", true, 1)
 	writer := NewDbWriter(conn, bson.E{}, false, -1)
 

--- a/executor/db_writer_test.go
+++ b/executor/db_writer_test.go
@@ -2779,6 +2779,73 @@ func TestResolveConflictFilter(t *testing.T) {
 	assert.Equal(t, bson.D{{"address.city", "shanghai"}}, filter)
 }
 
+func TestShouldSkipDupKeyOnInsert(t *testing.T) {
+	origin := conf.Options
+	defer func() { conf.Options = origin }()
+
+	err := fmt.Errorf(`E11000 duplicate key error collection: db.coll index: x_1 dup key: { x: 1 }`)
+	conf.Options = conf.Configuration{
+		IncrSyncExecutorDupKeyStrategy: utils.VarIncrSyncExecutorDupKeyStrategySkip,
+		IncrSyncExecutorDupKeySkipRulesMap: map[string]map[string]struct{}{
+			"db.coll": {"x_1": {}},
+		},
+	}
+
+	skip, indexName := shouldSkipDupKeyOnInsert("db", "coll", err)
+	assert.True(t, skip, "should be equal")
+	assert.Equal(t, "x_1", indexName, "should be equal")
+
+	skip, _ = shouldSkipDupKeyOnInsert("db", "other", err)
+	assert.False(t, skip, "should be equal")
+
+	conf.Options.IncrSyncExecutorDupKeySkipRulesMap = map[string]map[string]struct{}{
+		"db.coll": {"y_1": {}},
+	}
+	skip, indexName = shouldSkipDupKeyOnInsert("db", "coll", err)
+	assert.False(t, skip, "should be equal")
+	assert.Equal(t, "x_1", indexName, "should be equal")
+
+	conf.Options.IncrSyncExecutorDupKeySkipRulesMap = map[string]map[string]struct{}{
+		"db.coll": {"*": {}},
+	}
+	skip, indexName = shouldSkipDupKeyOnInsert("db", "coll", err)
+	assert.True(t, skip, "should be equal")
+	assert.Equal(t, "x_1", indexName, "should be equal")
+	assert.True(t, shouldSkipDupKeyIndex("db", "coll", "x_1"), "should be equal")
+	assert.False(t, shouldSkipDupKeyIndex("db", "other", "x_1"), "should be equal")
+
+	idErr := fmt.Errorf(`E11000 duplicate key error collection: db.coll index: _id_ dup key: { _id: 1 }`)
+	skip, indexName = shouldSkipDupKeyOnInsert("db", "coll", idErr)
+	assert.False(t, skip, "_id duplicate is handled by writer-level already-applied logic")
+	assert.Equal(t, "_id_", indexName, "should be equal")
+}
+
+func TestHandleDupKeyOnInsertStrategy(t *testing.T) {
+	origin := conf.Options
+	defer func() { conf.Options = origin }()
+
+	err := fmt.Errorf(`E11000 duplicate key error collection: db.coll index: x_1 dup key: { x: 1 }`)
+
+	conf.Options = conf.Configuration{IncrSyncExecutorDupKeyStrategy: utils.VarIncrSyncExecutorDupKeyStrategyIgnore}
+	assert.NoError(t, handleDupKeyOnInsert(nil, "db", "coll", nil, err, "test"), "should be equal")
+
+	conf.Options = conf.Configuration{IncrSyncExecutorDupKeyStrategy: utils.VarIncrSyncExecutorDupKeyStrategyError}
+	assert.Error(t, handleDupKeyOnInsert(nil, "db", "coll", nil, err, "test"), "should be equal")
+
+	conf.Options = conf.Configuration{
+		IncrSyncExecutorDupKeyStrategy: utils.VarIncrSyncExecutorDupKeyStrategySkip,
+		IncrSyncExecutorDupKeySkipRulesMap: map[string]map[string]struct{}{
+			"db.coll": {"x_1": {}},
+		},
+	}
+	assert.NoError(t, handleDupKeyOnInsert(nil, "db", "coll", nil, err, "test"), "should be equal")
+
+	conf.Options.IncrSyncExecutorDupKeySkipRulesMap = map[string]map[string]struct{}{
+		"db.coll": {"y_1": {}},
+	}
+	assert.Error(t, handleDupKeyOnInsert(nil, "db", "coll", nil, err, "test"), "should be equal")
+}
+
 func TestSingleWriterDeleteOnNonIdDupKey(t *testing.T) {
 	conn, err := utils.NewMongoCommunityConn(testMongoAddress, "primary", true,
 		utils.ReadWriteConcernDefault, utils.ReadWriteConcernDefault, "")

--- a/executor/dup_key_resolver.go
+++ b/executor/dup_key_resolver.go
@@ -119,7 +119,7 @@ func splitDotted(field string) []string {
 func deleteConflictAndRetry(collection *mongo.Collection, updateFilter interface{},
 	doc bson.D, dupErr error, opts *interface{}) (bool, error) {
 
-	if !conf.Options.IncrSyncExecutorDeleteOnNonIdDupKey {
+	if conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry {
 		return false, nil
 	}
 	if !utils.DuplicateKey(dupErr) {

--- a/executor/duplicate.go
+++ b/executor/duplicate.go
@@ -8,7 +8,13 @@ import (
 // RecordDuplicatedOplog
 // Write dup oplog in DB APPConflictDatabase
 func RecordDuplicatedOplog(conn *utils.MongoCommunityConn, coll string, records []*OplogRecord) {
+	if conn == nil {
+		return
+	}
 	for _, record := range records {
+		if record == nil || record.original == nil || record.original.partialLog == nil {
+			continue
+		}
 		log := record.original.partialLog
 		switch conf.Options.IncrSyncConflictWriteTo {
 		case DumpConflictToDB:

--- a/executor/duplicate_key_strategy.go
+++ b/executor/duplicate_key_strategy.go
@@ -1,0 +1,38 @@
+package executor
+
+import (
+	"fmt"
+
+	conf "github.com/alibaba/MongoShake/v2/collector/configure"
+	utils "github.com/alibaba/MongoShake/v2/common"
+	l "github.com/alibaba/MongoShake/v2/pkg/log"
+)
+
+func handleDupKeyOnInsert(conn *utils.MongoCommunityConn, database, collection string,
+	oplogs []*OplogRecord, err error, logPrefix string) error {
+
+	if !utils.DuplicateKey(err) {
+		return err
+	}
+
+	switch conf.Options.IncrSyncExecutorDupKeyStrategy {
+	case "", utils.VarIncrSyncExecutorDupKeyStrategyIgnore:
+		RecordDuplicatedOplog(conn, collection, oplogs)
+		l.Logger.Infof("%s duplicated oplogs ignored, ns[%s.%s], err[%v]",
+			logPrefix, database, collection, err)
+		return nil
+	case utils.VarIncrSyncExecutorDupKeyStrategySkip:
+		if skip, indexName := shouldSkipDupKeyOnInsert(database, collection, err); skip {
+			RecordDuplicatedOplog(conn, collection, oplogs)
+			l.Logger.Warnf("%s duplicated oplogs skipped, ns[%s.%s], index[%s], err[%v]",
+				logPrefix, database, collection, indexName, err)
+			return nil
+		}
+		return err
+	case utils.VarIncrSyncExecutorDupKeyStrategyError,
+		utils.VarIncrSyncExecutorDupKeyStrategyDeleteAndRetry:
+		return err
+	default:
+		return fmt.Errorf("unknown dup key strategy[%s]: %w", conf.Options.IncrSyncExecutorDupKeyStrategy, err)
+	}
+}

--- a/executor/duplicate_skip.go
+++ b/executor/duplicate_skip.go
@@ -22,12 +22,22 @@ func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, str
 		return false, ""
 	}
 
-	if _, ok := allowedIndexes["*"]; ok {
-		return true, indexName
-	}
-	if _, ok := allowedIndexes[indexName]; ok {
-		return true, indexName
+	return shouldSkipDupKeyIndex(database, collection, indexName), indexName
+}
+
+func shouldSkipDupKeyIndex(database, collection, indexName string) bool {
+	if indexName == "" {
+		return false
 	}
 
-	return false, indexName
+	ns := database + "." + collection
+	allowedIndexes, ok := conf.Options.IncrSyncExecutorDupKeySkipRulesMap[ns]
+	if !ok {
+		return false
+	}
+	if _, ok := allowedIndexes["*"]; ok {
+		return true
+	}
+	_, ok = allowedIndexes[indexName]
+	return ok
 }

--- a/executor/duplicate_skip.go
+++ b/executor/duplicate_skip.go
@@ -10,12 +10,13 @@ import (
 var duplicateKeyIndexRegexp = regexp.MustCompile(`index: ([^ ]+) dup key`)
 
 func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, string) {
-	if !conf.Options.IncrSyncExecutorSkipDupKeyOnInsert || !utils.DuplicateKey(err) {
+	if conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategySkip ||
+		!utils.DuplicateKey(err) {
 		return false, ""
 	}
 
 	ns := database + "." + collection
-	allowedIndexes, ok := conf.Options.IncrSyncExecutorSkipDupKeyOnInsertRuleMap[ns]
+	allowedIndexes, ok := conf.Options.IncrSyncExecutorDupKeySkipRulesMap[ns]
 	if !ok {
 		return false, ""
 	}

--- a/executor/duplicate_skip.go
+++ b/executor/duplicate_skip.go
@@ -11,12 +11,6 @@ func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, str
 		return false, ""
 	}
 
-	ns := database + "." + collection
-	allowedIndexes, ok := conf.Options.IncrSyncExecutorDupKeySkipRulesMap[ns]
-	if !ok {
-		return false, ""
-	}
-
 	indexName := parseDupKeyIndexName(err)
 	if indexName == "" {
 		return false, ""

--- a/executor/duplicate_skip.go
+++ b/executor/duplicate_skip.go
@@ -1,0 +1,48 @@
+package executor
+
+import (
+	"regexp"
+
+	conf "github.com/alibaba/MongoShake/v2/collector/configure"
+	utils "github.com/alibaba/MongoShake/v2/common"
+)
+
+var duplicateKeyIndexRegexp = regexp.MustCompile(`index: ([^ ]+) dup key`)
+
+func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, string) {
+	if !conf.Options.IncrSyncExecutorSkipDupKeyOnInsert || !utils.DuplicateKey(err) {
+		return false, ""
+	}
+
+	ns := database + "." + collection
+	allowedIndexes, ok := conf.Options.IncrSyncExecutorSkipDupKeyOnInsertRuleMap[ns]
+	if !ok {
+		return false, ""
+	}
+
+	indexName := extractDuplicateKeyIndexName(err)
+	if indexName == "" {
+		return false, ""
+	}
+
+	if _, ok := allowedIndexes["*"]; ok {
+		return true, indexName
+	}
+	if _, ok := allowedIndexes[indexName]; ok {
+		return true, indexName
+	}
+
+	return false, indexName
+}
+
+func extractDuplicateKeyIndexName(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	matches := duplicateKeyIndexRegexp.FindStringSubmatch(err.Error())
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}

--- a/executor/duplicate_skip.go
+++ b/executor/duplicate_skip.go
@@ -1,13 +1,9 @@
 package executor
 
 import (
-	"regexp"
-
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	utils "github.com/alibaba/MongoShake/v2/common"
 )
-
-var duplicateKeyIndexRegexp = regexp.MustCompile(`index: ([^ ]+) dup key`)
 
 func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, string) {
 	if conf.Options.IncrSyncExecutorDupKeyStrategy != utils.VarIncrSyncExecutorDupKeyStrategySkip ||
@@ -21,7 +17,7 @@ func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, str
 		return false, ""
 	}
 
-	indexName := extractDuplicateKeyIndexName(err)
+	indexName := parseDupKeyIndexName(err)
 	if indexName == "" {
 		return false, ""
 	}
@@ -34,16 +30,4 @@ func shouldSkipDupKeyOnInsert(database, collection string, err error) (bool, str
 	}
 
 	return false, indexName
-}
-
-func extractDuplicateKeyIndexName(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	matches := duplicateKeyIndexRegexp.FindStringSubmatch(err.Error())
-	if len(matches) != 2 {
-		return ""
-	}
-	return matches[1]
 }


### PR DESCRIPTION
## 背景

MongoShake 当前已经支持：

```ini
incr_sync.executor.insert_on_dup_update = true
```

即：当增量同步回放 `insert` oplog 时，如果目的端出现重复键错误，MongoShake 会尝试把这条 `insert` 改写成 `update` / `upsert` 再执行。

但在实际迁移场景中，可能遇到一类特殊冲突：

```text
E11000 duplicate key error collection: <db>.<collection>
index: <unique_index_name>
dup key: {
  <business_field_1>: <value_1>,
  <business_field_2>: <value_2>
}
```

这类场景中，源端可能存在两条 `_id` 不同、但业务唯一键相同的文档：

```js
{
  _id: ObjectId("<object_id_1>"),
  "<business_field_1>": "<value_1>",
  "<business_field_2>": "<value_2>"
}
```

```js
{
  _id: ObjectId("<object_id_2>"),
  "<business_field_1>": "<value_1>",
  "<business_field_2>": "<value_2>"
}
```

而目的端存在更严格的唯一索引，例如：

```js
{
  "<business_field_1>": 1,
  "<business_field_2>": 1
}
```

因此目的端只能保留其中一条。

当 MongoShake 回放第二条 `insert` 时：

1. 直接 `insert` 失败，报 duplicate key；
2. `insert_on_dup_update` 生效，MongoShake 改成按 `_id` 做 `update` / `upsert`；
3. 目的端不存在第二条文档的 `_id`；
4. `upsert` 退化成插入；
5. 插入再次命中业务唯一索引；
6. 最终 replay 报 `CRITICAL` 并停止。

对于“目的端唯一约束是预期行为，并且希望以目的端现有数据为准”的迁移场景，需要一种可配置的方式跳过这类 insert oplog，避免人工反复推进 checkpoint。

---

## 本次改动

本 PR 新增了一个配置化跳过机制，用于处理：

```text
insert oplog
  -> insert duplicate key
  -> insert_on_dup_update 兜底
  -> 兜底 update/upsert 仍然 duplicate key
  -> 命中 namespace / index 白名单
  -> 记录冲突
  -> 跳过当前 insert oplog
  -> 继续回放后续 oplog
```

---

## 新增配置

新增两个配置项：

```ini
incr_sync.executor.skip_dup_key_on_insert = false
incr_sync.executor.skip_dup_key_on_insert.rules =
```

规则格式：

```ini
db.collection:index1,index2;db.collection:*
```

示例：

```ini
incr_sync.executor.skip_dup_key_on_insert = true
incr_sync.executor.skip_dup_key_on_insert.rules = db1.collection1:unique_index_1;db1.collection2:unique_index_2
```

如果希望某些集合上的所有唯一索引冲突都跳过，可以使用 `*`：

```ini
incr_sync.executor.skip_dup_key_on_insert.rules = db1.collection1:*;db1.collection2:*
```

---

## 配置语义

### `incr_sync.executor.skip_dup_key_on_insert`

是否开启 insert duplicate 二次兜底失败后的跳过逻辑。

默认值：

```ini
false
```

即默认行为保持不变。

---

### `incr_sync.executor.skip_dup_key_on_insert.rules`

配置允许跳过的 namespace 和唯一索引名。

格式：

```ini
db.collection:index1,index2;db.collection:*
```

含义：

```ini
db1.collection1:unique_index_1
```

表示：

```text
仅当 namespace 为 db1.collection1，
且 duplicate key 冲突索引为 unique_index_1 时，
才允许跳过该 insert oplog。
```

```ini
db1.collection1:*
```

表示：

```text
namespace 为 db1.collection1 时，
insert_on_dup_update 兜底后仍 duplicate 的 insert oplog，
不限制具体唯一索引名，均允许跳过。
```

---

## 启动校验

新增了配置校验逻辑：

- 如果 `skip_dup_key_on_insert = true`，则 `rules` 不能为空；
- 每条规则必须符合：
  ```text
  db.collection:index1,index2
  ```
- namespace 必须是：
  ```text
  db.collection
  ```
- index 列表不能包含空值。

如果配置错误，MongoShake 启动时会直接报错，避免运行期出现不可预期行为。

---

## 实现细节

### 1. 解析 duplicate key 中的索引名

从 MongoDB duplicate key 错误文本中解析索引名，例如：

```text
index: unique_index_name dup key
```

解析得到：

```text
unique_index_name
```

---

### 2. 按 namespace + index 白名单判断是否允许跳过

只有同时满足以下条件才跳过：

- 新配置已开启；
- 当前错误是 duplicate key；
- 当前 namespace 命中规则；
- 当前 duplicate key 的 index 命中规则；
- 或当前 namespace 配置了 `*`。

---

### 3. 只跳过单条 oplog，不跳过整批

MongoShake 批量写入失败后，原本会 fallback 到 single writer 逐条重试。

本 PR 将跳过逻辑放在 single writer 的 `doUpdateOnInsert` 阶段：

```text
BulkWriter
  -> bulk insert failed
  -> duplicate key
  -> doUpdateOnInsert
  -> bulk update/upsert failed
  -> fallback SingleWriter
  -> single doUpdateOnInsert
  -> 单条判断是否跳过
```

这样可以避免直接跳过整个 bulk batch，降低误跳正常 oplog 的风险。

---

### 4. 跳过时记录冲突

命中跳过规则时，会调用现有冲突记录逻辑：

```go
RecordDuplicatedOplog(...)
```

如果配置了：

```ini
incr_sync.conflict_write_to = db
```

则被跳过的文档会写入目的端冲突库：

```text
<conflict_database>.<collection>
```

同时日志会打印：

```text
skip duplicated insert after update_on_insert failed, ns[...], index[...], id[...], ts[...], err[...]
```

---

### 5. 增加 bulk fallback 防御性检查

在 bulk writer fallback 到 single writer 时，原逻辑会使用：

```go
oplogs[index:]
```

本 PR 增加了 index 边界检查：

```go
if index < 0 || index >= len(oplogs) {
    return err
}
```

避免异常情况下由于 index 不合法导致 slice 越界 panic。

---

## 修改文件

- `collector/configure/configure.go`
  - 新增配置字段；
  - 新增解析后的规则 map。

- `cmd/collector/sanitize.go`
  - 新增 `skip_dup_key_on_insert.rules` 解析和校验。

- `executor/duplicate_skip.go`
  - 新增 duplicate key 索引名解析；
  - 新增 namespace / index 规则匹配逻辑。

- `executor/db_writer_single.go`
  - 在 `insert_on_dup_update` 兜底仍 duplicate 时，根据规则跳过单条 oplog。

- `executor/db_writer_bulk.go`
  - fallback 到 single writer 前增加 index 边界检查。

- `conf/collector.conf`
  - 增加新配置项说明。

---

## 使用示例

### 只跳过指定集合的指定唯一索引

```ini
incr_sync.executor.skip_dup_key_on_insert = true
incr_sync.executor.skip_dup_key_on_insert.rules = db1.collection1:unique_index_1;db1.collection2:unique_index_2
```

---

### 跳过指定集合的所有唯一索引冲突

```ini
incr_sync.executor.skip_dup_key_on_insert = true
incr_sync.executor.skip_dup_key_on_insert.rules = db1.collection1:*;db1.collection2:*;db2.collection1:*
```

---

## 运行时验证方式

### 1. 确认二进制包含新逻辑

```bash
strings ./collector | grep -F "skip duplicated insert after update_on_insert failed"
```

如果有输出，说明当前二进制包含该功能。

---

### 2. 确认配置已开启

```bash
grep -n "skip_dup_key_on_insert" <collector_config_file>
```

期望看到：

```ini
incr_sync.executor.skip_dup_key_on_insert = true
incr_sync.executor.skip_dup_key_on_insert.rules = ...
```

---

### 3. 查看跳过日志

```bash
grep -n "skip duplicated insert after update_on_insert failed" <collector_log_file> | tail -20
```

如果生效，会看到类似：

```text
skip duplicated insert after update_on_insert failed, ns[db.collection], index[unique_index_name], id[...], ts[...], err[...]
```

---

### 4. 查看同步位点是否继续推进

```bash
curl -s http://127.0.0.1:<http_port>/repl | jq -r '.[] | [.replset, .logs_success, .lsn.time, .lsn_ack.time, .lsn_ckpt.time, .now.time, .fetcher_status] | @tsv'
```

生效后，之前卡住的 replset 应该继续推进：

```text
logs_success 增加
lsn_ack.time 推进
lsn_ckpt.time 推进
```

---

## 风险说明

该功能是显式 opt-in，默认关闭。

开启后需要注意：

1. **目标端可能与源端文档级不完全一致**
   - 被跳过的源端 insert 文档不会出现在目的端。

2. **适用于“目的端为准”的场景**
   - 例如目的端有更严格的唯一索引；
   - 源端重复业务键数据被认为是脏数据；
   - 允许目的端只保留已有文档。

3. **后续 update/delete 仍需关注**
   - 如果源端后续对被跳过的 `_id` 产生 update/delete，目的端可能不存在该 `_id`；
   - 需要结合现有 upsert / error handling 策略继续观察。

4. **不建议全局无差别开启**
   - 应优先使用 namespace / index 白名单；
   - 避免掩盖真实同步错误。

---

## 兼容性

默认配置为：

```ini
incr_sync.executor.skip_dup_key_on_insert = false
```

因此默认行为不变。

只有显式开启，并且 namespace / index 命中规则时，才会跳过对应 insert oplog。

---

## 验证情况

已编译 Linux `amd64` 版本：

```text
bin/collector
bin/receiver
```

文件类型：

```text
ELF 64-bit LSB executable, x86-64, statically linked
```

测试情况：

```bash
go test ./cmd/collector
```

通过。

`go test ./executor` 未能在本地完整通过，原因是现有测试依赖外部 MongoDB 实例，本地环境无法连接，触发 server selection timeout。该失败与本次代码逻辑无关。

---

## 总结

本 PR 提供了一个显式、可控、按 namespace / index 白名单生效的机制，用于处理：

```text
insert duplicate
-> insert_on_dup_update 兜底
-> 仍然 duplicate
```

这类在迁移场景中常见的业务唯一键冲突问题。

默认行为保持不变；只有用户明确配置后，MongoShake 才会跳过命中规则的 insert oplog，并继续增量回放。