### PR TITLE
feat: enhance prometheus sync metrics

### DIFF
--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -122,6 +122,7 @@ func main() {
 
 func startup() {
 	initStartupHTTPApis()
+	utils.SetMongoShakeInfo(conf.Options.Id)
 
 	ReplCord := &coordinator.ReplicationCoordinator{
 		MongoD: make([]*utils.MongoSource, len(conf.Options.MongoUrls)),

--- a/cmd/collector/collector.go
+++ b/cmd/collector/collector.go
@@ -26,7 +26,7 @@ type Exit struct{ Code int }
 var (
 	fullSyncInitHttpApiFunc    = utils.FullSyncInitHttpApi
 	incrSyncInitHttpApiFunc    = utils.IncrSyncInitHttpApi
-	prometheusInitHttpApiFunc  = utils.PrometheusInitHttpApi
+	prometheusInitHttpApiFunc  = utils.PrometheusInitHttpApiWithName
 	startPrometheusHttpApiFunc = startPrometheusHttpApi
 	registerConfHttpApiFunc    = registerConfHttpApi
 	selectLeaderFunc           = selectLeader
@@ -174,7 +174,7 @@ func startup() {
 }
 
 func initStartupHTTPApis() {
-	prometheusInitHttpApiFunc(conf.Options.PromHTTPListenPort)
+	prometheusInitHttpApiFunc(conf.Options.PromHTTPListenPort, conf.Options.Id)
 	startPrometheusHttpApiFunc()
 
 	// leader election blocks standby nodes before full/incr runtime APIs are exposed.

--- a/cmd/collector/collector_test.go
+++ b/cmd/collector/collector_test.go
@@ -30,6 +30,7 @@ func TestInitStartupHTTPApisStartPrometheusBeforeLeaderElection(t *testing.T) {
 	}()
 
 	conf.Options = conf.Configuration{
+		Id:                     "rs-startup",
 		FullSyncHTTPListenPort: 9101,
 		IncrSyncHTTPListenPort: 9100,
 		PromHTTPListenPort:     9102,
@@ -40,7 +41,9 @@ func TestInitStartupHTTPApisStartPrometheusBeforeLeaderElection(t *testing.T) {
 	releaseLeader := make(chan struct{})
 	done := make(chan struct{})
 
-	prometheusInitHttpApiFunc = func(int) {
+	prometheusInitHttpApiFunc = func(port int, name string) {
+		assert.Equal(t, 9102, port, "should be equal")
+		assert.Equal(t, "rs-startup", name, "should be equal")
 		order <- "prometheus-init"
 	}
 	startPrometheusHttpApiFunc = func() {

--- a/collector/coordinator/full.go
+++ b/collector/coordinator/full.go
@@ -58,12 +58,22 @@ func getTimestampMap(sources []*utils.MongoSource, sslRootFile string) (map[stri
 	return ckptMap, nil
 }
 
-func (coordinator *ReplicationCoordinator) startDocumentReplication() error {
+func (coordinator *ReplicationCoordinator) startDocumentReplication() (err error) {
+	utils.SetMongoShakeSyncStage(conf.Options.Id, utils.TypeFull)
+	utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeFull, utils.SyncStateRunning)
+	defer func() {
+		if r := recover(); r != nil {
+			utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeFull, utils.SyncStateError)
+			panic(r)
+		}
+		if err != nil {
+			utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeFull, utils.SyncStateError)
+		}
+	}()
 
 	fromIsSharding := coordinator.SourceIsSharding()
 
 	var shardingChunkMap sharding.ShardingChunkMap
-	var err error
 	// init orphan sharding chunk map if source is mongod(get data directly from mongod)
 	if fromIsSharding && coordinator.MongoS == nil {
 		l.Logger.Infof("source is mongod, need to fetching chunk map")
@@ -202,6 +212,7 @@ func (coordinator *ReplicationCoordinator) startDocumentReplication() error {
 	// wait all db finished
 	wg.Wait()
 	if replError != nil {
+		utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeFull, utils.SyncStateError)
 		return replError
 	}
 
@@ -239,6 +250,7 @@ func (coordinator *ReplicationCoordinator) startDocumentReplication() error {
 	}
 
 	l.Logger.Infof("document syncer sync end")
+	utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeFull, utils.SyncStateDone)
 	return nil
 }
 

--- a/collector/coordinator/incr.go
+++ b/collector/coordinator/incr.go
@@ -14,7 +14,18 @@ import (
 
 func (coordinator *ReplicationCoordinator) startOplogReplication(oplogStartPosition interface{},
 	fullSyncFinishPosition int64,
-	startTsMap map[string]int64) error {
+	startTsMap map[string]int64) (err error) {
+	utils.SetMongoShakeSyncStage(conf.Options.Id, utils.TypeIncr)
+	utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeIncr, utils.SyncStateRunning)
+	defer func() {
+		if r := recover(); r != nil {
+			utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeIncr, utils.SyncStateError)
+			panic(r)
+		}
+		if err != nil {
+			utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeIncr, utils.SyncStateError)
+		}
+	}()
 
 	// prepare all syncer. only one syncer while source is ReplicaSet or mongos
 	// otherwise one syncer connects to one shard
@@ -60,6 +71,7 @@ func (coordinator *ReplicationCoordinator) startOplogReplication(oplogStartPosit
 		syncer := coordinator.syncerGroup[i%len(coordinator.syncerGroup)]
 		w := collector.NewWorker(syncer, uint32(i))
 		if !w.Init() {
+			utils.SetMongoShakeSyncState(conf.Options.Id, utils.TypeIncr, utils.SyncStateError)
 			return errors.New("worker initialize error")
 		}
 		w.SetInitSyncFinishTs(fullSyncFinishPosition)

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -407,7 +407,9 @@ func (syncer *DBSyncer) Start() (syncError error) {
 
 	// create metric for each collection
 	for _, ns := range nsList {
-		syncer.metricNsMap[ns] = NewCollectionMetric()
+		metric := NewCollectionMetric()
+		syncer.metricNsMap[ns] = metric
+		syncer.updateSingleCollectionProgressMetric(ns, metric)
 	}
 	atomic.StoreInt64(&syncer.totalCollections, int64(len(nsList)))
 	atomic.StoreInt64(&syncer.waitingCollections, int64(len(nsList)))
@@ -479,8 +481,8 @@ func (syncer *DBSyncer) collectionSync(collExecutorId int, ns utils.NS, toNS uti
 
 	// metric
 	collectionMetric := syncer.metricNsMap[ns]
-	syncer.markCollectionProcessing(collectionMetric)
 	collectionMetric.TotalCount = splitter.count
+	syncer.markCollectionProcessing(ns, collectionMetric)
 
 	// run in several pieces
 	var wg sync.WaitGroup
@@ -516,7 +518,7 @@ func (syncer *DBSyncer) collectionSync(collExecutorId int, ns utils.NS, toNS uti
 	// fetch index
 
 	// set collection finish
-	syncer.markCollectionFinished(collectionMetric)
+	syncer.markCollectionFinished(ns, collectionMetric)
 
 	return nil
 }
@@ -533,7 +535,7 @@ func (syncer *DBSyncer) splitSync(reader *DocumentReader, colExecutor *Collectio
 		if err != nil {
 			return fmt.Errorf("splitter reader[%v] get next document failed: %v", reader, err)
 		} else if doc == nil {
-			atomic.AddUint64(&collectionMetric.FinishCount, uint64(len(buffer)))
+			syncer.addCollectionFinishedDocs(reader.ns, collectionMetric, uint64(len(buffer)))
 			colExecutor.Sync(buffer)
 			syncer.replMetric.AddSuccess(uint64(len(buffer))) // only used to calculate the tps which is extract from "success"
 			break
@@ -542,7 +544,7 @@ func (syncer *DBSyncer) splitSync(reader *DocumentReader, colExecutor *Collectio
 		syncer.replMetric.AddGet(1)
 
 		if bufferByteSize+len(doc) > MaxBufferByteSize || len(buffer) >= bufferSize {
-			atomic.AddUint64(&collectionMetric.FinishCount, uint64(len(buffer)))
+			syncer.addCollectionFinishedDocs(reader.ns, collectionMetric, uint64(len(buffer)))
 			colExecutor.Sync(buffer)
 			syncer.replMetric.AddSuccess(uint64(len(buffer))) // only used to calculate the tps which is extract from "success"
 			buffer = make([]*bson.Raw, 0, bufferSize)
@@ -617,7 +619,7 @@ func (syncer *DBSyncer) RestAPI() {
 	})
 }
 
-func (syncer *DBSyncer) markCollectionProcessing(collectionMetric *CollectionMetric) {
+func (syncer *DBSyncer) markCollectionProcessing(ns utils.NS, collectionMetric *CollectionMetric) {
 	if collectionMetric == nil {
 		return
 	}
@@ -628,9 +630,10 @@ func (syncer *DBSyncer) markCollectionProcessing(collectionMetric *CollectionMet
 	}
 	collectionMetric.CollectionStatus = StatusProcessing
 	syncer.updateCollectionProgressMetrics()
+	syncer.updateSingleCollectionProgressMetric(ns, collectionMetric)
 }
 
-func (syncer *DBSyncer) markCollectionFinished(collectionMetric *CollectionMetric) {
+func (syncer *DBSyncer) markCollectionFinished(ns utils.NS, collectionMetric *CollectionMetric) {
 	if collectionMetric == nil {
 		return
 	}
@@ -644,15 +647,47 @@ func (syncer *DBSyncer) markCollectionFinished(collectionMetric *CollectionMetri
 	atomic.AddInt64(&syncer.finishedCollections, 1)
 	collectionMetric.CollectionStatus = StatusFinish
 	syncer.updateCollectionProgressMetrics()
+	syncer.updateSingleCollectionProgressMetric(ns, collectionMetric)
 }
 
 func (syncer *DBSyncer) updateCollectionProgressMetrics() {
+	total := atomic.LoadInt64(&syncer.totalCollections)
+	finished := atomic.LoadInt64(&syncer.finishedCollections)
+	progressRatio := 1.0
+	if total > 0 {
+		progressRatio = float64(finished) / float64(total)
+	}
+
 	utils.FullSyncCollectionsTotalProm.WithLabelValues(syncer.fromReplset, utils.TypeFull).
-		Set(float64(atomic.LoadInt64(&syncer.totalCollections)))
+		Set(float64(total))
 	utils.FullSyncCollectionsFinishedProm.WithLabelValues(syncer.fromReplset, utils.TypeFull).
-		Set(float64(atomic.LoadInt64(&syncer.finishedCollections)))
+		Set(float64(finished))
 	utils.FullSyncCollectionsProcessingProm.WithLabelValues(syncer.fromReplset, utils.TypeFull).
 		Set(float64(atomic.LoadInt64(&syncer.processingCollections)))
 	utils.FullSyncCollectionsWaitingProm.WithLabelValues(syncer.fromReplset, utils.TypeFull).
 		Set(float64(atomic.LoadInt64(&syncer.waitingCollections)))
+	utils.FullSyncCollectionsProgressRatioProm.WithLabelValues(syncer.fromReplset, utils.TypeFull).
+		Set(progressRatio)
+}
+
+func (syncer *DBSyncer) addCollectionFinishedDocs(ns utils.NS, collectionMetric *CollectionMetric, n uint64) {
+	if collectionMetric == nil {
+		return
+	}
+	atomic.AddUint64(&collectionMetric.FinishCount, n)
+	syncer.updateSingleCollectionProgressMetric(ns, collectionMetric)
+}
+
+func (syncer *DBSyncer) updateSingleCollectionProgressMetric(ns utils.NS, collectionMetric *CollectionMetric) {
+	if collectionMetric == nil {
+		return
+	}
+	utils.FullSyncCollectionStatusProm.WithLabelValues(syncer.fromReplset, utils.TypeFull, ns.Database, ns.Collection).
+		Set(collectionMetric.StatusCode())
+	utils.FullSyncCollectionDocsTotalProm.WithLabelValues(syncer.fromReplset, utils.TypeFull, ns.Database, ns.Collection).
+		Set(float64(atomic.LoadUint64(&collectionMetric.TotalCount)))
+	utils.FullSyncCollectionDocsFinishedProm.WithLabelValues(syncer.fromReplset, utils.TypeFull, ns.Database, ns.Collection).
+		Set(float64(atomic.LoadUint64(&collectionMetric.FinishCount)))
+	utils.FullSyncCollectionProgressRatioProm.WithLabelValues(syncer.fromReplset, utils.TypeFull, ns.Database, ns.Collection).
+		Set(collectionMetric.ProgressRatio())
 }

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -481,7 +481,7 @@ func (syncer *DBSyncer) collectionSync(collExecutorId int, ns utils.NS, toNS uti
 
 	// metric
 	collectionMetric := syncer.metricNsMap[ns]
-	collectionMetric.TotalCount = splitter.count
+	atomic.StoreUint64(&collectionMetric.TotalCount, splitter.count)
 	syncer.markCollectionProcessing(ns, collectionMetric)
 
 	// run in several pieces
@@ -599,7 +599,7 @@ func (syncer *DBSyncer) RestAPI() {
 		ret.TotalCollection = len(syncer.metricNsMap)
 		for ns, collectionMetric := range syncer.metricNsMap {
 			ret.CollectionMetric[ns.Str()] = collectionMetric.String()
-			switch collectionMetric.CollectionStatus {
+			switch collectionMetric.Status() {
 			case StatusWaitStart:
 				ret.WaitCollection += 1
 			case StatusProcessing:
@@ -624,11 +624,11 @@ func (syncer *DBSyncer) markCollectionProcessing(ns utils.NS, collectionMetric *
 		return
 	}
 
-	if collectionMetric.CollectionStatus == StatusWaitStart {
+	if collectionMetric.Status() == StatusWaitStart {
 		atomic.AddInt64(&syncer.waitingCollections, -1)
 		atomic.AddInt64(&syncer.processingCollections, 1)
 	}
-	collectionMetric.CollectionStatus = StatusProcessing
+	collectionMetric.SetStatus(StatusProcessing)
 	syncer.updateCollectionProgressMetrics()
 	syncer.updateSingleCollectionProgressMetric(ns, collectionMetric)
 }
@@ -638,14 +638,14 @@ func (syncer *DBSyncer) markCollectionFinished(ns utils.NS, collectionMetric *Co
 		return
 	}
 
-	switch collectionMetric.CollectionStatus {
+	switch collectionMetric.Status() {
 	case StatusWaitStart:
 		atomic.AddInt64(&syncer.waitingCollections, -1)
 	case StatusProcessing:
 		atomic.AddInt64(&syncer.processingCollections, -1)
 	}
 	atomic.AddInt64(&syncer.finishedCollections, 1)
-	collectionMetric.CollectionStatus = StatusFinish
+	collectionMetric.SetStatus(StatusFinish)
 	syncer.updateCollectionProgressMetrics()
 	syncer.updateSingleCollectionProgressMetric(ns, collectionMetric)
 }

--- a/collector/docsyncer/metric.go
+++ b/collector/docsyncer/metric.go
@@ -5,30 +5,39 @@ import (
 	"sync/atomic"
 )
 
-type Status string
+type Status int32
 
 const (
-	StatusWaitStart  Status = "wait start"
-	StatusProcessing Status = "in processing"
-	StatusFinish     Status = "finish"
+	StatusWaitStart Status = iota
+	StatusProcessing
+	StatusFinish
 )
 
 type CollectionMetric struct {
-	CollectionStatus Status
+	CollectionStatus int32
 	TotalCount       uint64
 	FinishCount      uint64
 }
 
 func NewCollectionMetric() *CollectionMetric {
 	return &CollectionMetric{
-		CollectionStatus: StatusWaitStart,
+		CollectionStatus: int32(StatusWaitStart),
 	}
+}
+
+func (cm *CollectionMetric) Status() Status {
+	return Status(atomic.LoadInt32(&cm.CollectionStatus))
+}
+
+func (cm *CollectionMetric) SetStatus(status Status) {
+	atomic.StoreInt32(&cm.CollectionStatus, int32(status))
 }
 
 func (cm *CollectionMetric) String() string {
 	totalCount := atomic.LoadUint64(&cm.TotalCount)
 	finishCount := atomic.LoadUint64(&cm.FinishCount)
-	if cm.CollectionStatus == StatusWaitStart {
+	status := cm.Status()
+	if status == StatusWaitStart {
 		return fmt.Sprintf("-")
 	}
 
@@ -41,7 +50,7 @@ func (cm *CollectionMetric) String() string {
 }
 
 func (cm *CollectionMetric) StatusCode() float64 {
-	switch cm.CollectionStatus {
+	switch cm.Status() {
 	case StatusProcessing:
 		return 1
 	case StatusFinish:
@@ -54,10 +63,11 @@ func (cm *CollectionMetric) StatusCode() float64 {
 func (cm *CollectionMetric) ProgressRatio() float64 {
 	totalCount := atomic.LoadUint64(&cm.TotalCount)
 	finishCount := atomic.LoadUint64(&cm.FinishCount)
-	if cm.CollectionStatus == StatusWaitStart {
+	status := cm.Status()
+	if status == StatusWaitStart {
 		return 0
 	}
-	if cm.CollectionStatus == StatusFinish || totalCount == 0 {
+	if status == StatusFinish || totalCount == 0 {
 		return 1
 	}
 	return float64(finishCount) / float64(totalCount)

--- a/collector/docsyncer/metric.go
+++ b/collector/docsyncer/metric.go
@@ -1,6 +1,9 @@
 package docsyncer
 
-import "fmt"
+import (
+	"fmt"
+	"sync/atomic"
+)
 
 type Status string
 
@@ -23,14 +26,39 @@ func NewCollectionMetric() *CollectionMetric {
 }
 
 func (cm *CollectionMetric) String() string {
+	totalCount := atomic.LoadUint64(&cm.TotalCount)
+	finishCount := atomic.LoadUint64(&cm.FinishCount)
 	if cm.CollectionStatus == StatusWaitStart {
 		return fmt.Sprintf("-")
 	}
 
-	if cm.TotalCount == 0 {
-		return fmt.Sprintf("100%% (%v/%v)", cm.FinishCount, cm.TotalCount)
+	if totalCount == 0 {
+		return fmt.Sprintf("100%% (%v/%v)", finishCount, totalCount)
 	} else {
-		return fmt.Sprintf("%.2f%% (%v/%v)", float64(cm.FinishCount)/float64(cm.TotalCount)*100,
-			cm.FinishCount, cm.TotalCount)
+		return fmt.Sprintf("%.2f%% (%v/%v)", float64(finishCount)/float64(totalCount)*100,
+			finishCount, totalCount)
 	}
+}
+
+func (cm *CollectionMetric) StatusCode() float64 {
+	switch cm.CollectionStatus {
+	case StatusProcessing:
+		return 1
+	case StatusFinish:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func (cm *CollectionMetric) ProgressRatio() float64 {
+	totalCount := atomic.LoadUint64(&cm.TotalCount)
+	finishCount := atomic.LoadUint64(&cm.FinishCount)
+	if cm.CollectionStatus == StatusWaitStart {
+		return 0
+	}
+	if cm.CollectionStatus == StatusFinish || totalCount == 0 {
+		return 1
+	}
+	return float64(finishCount) / float64(totalCount)
 }

--- a/collector/docsyncer/prom_metrics_test.go
+++ b/collector/docsyncer/prom_metrics_test.go
@@ -22,7 +22,7 @@ func TestPrometheusHandlerExposesFullSyncProgressMetrics(t *testing.T) {
 	secondNS := utils.NS{Database: "db1", Collection: "orders"}
 	first := NewCollectionMetric()
 	second := NewCollectionMetric()
-	first.TotalCount = 100
+	atomic.StoreUint64(&first.TotalCount, 100)
 	syncer.updateSingleCollectionProgressMetric(firstNS, first)
 	syncer.updateSingleCollectionProgressMetric(secondNS, second)
 	syncer.markCollectionProcessing(firstNS, first)

--- a/collector/docsyncer/prom_metrics_test.go
+++ b/collector/docsyncer/prom_metrics_test.go
@@ -18,11 +18,17 @@ func TestPrometheusHandlerExposesFullSyncProgressMetrics(t *testing.T) {
 	atomic.StoreInt64(&syncer.waitingCollections, 2)
 	syncer.updateCollectionProgressMetrics()
 
+	firstNS := utils.NS{Database: "db1", Collection: "users"}
+	secondNS := utils.NS{Database: "db1", Collection: "orders"}
 	first := NewCollectionMetric()
 	second := NewCollectionMetric()
-	syncer.markCollectionProcessing(first)
-	syncer.markCollectionFinished(first)
-	syncer.markCollectionProcessing(second)
+	first.TotalCount = 100
+	syncer.updateSingleCollectionProgressMetric(firstNS, first)
+	syncer.updateSingleCollectionProgressMetric(secondNS, second)
+	syncer.markCollectionProcessing(firstNS, first)
+	syncer.addCollectionFinishedDocs(firstNS, first, 25)
+	syncer.markCollectionFinished(firstNS, first)
+	syncer.markCollectionProcessing(secondNS, second)
 
 	request := httptest.NewRequest("GET", "/metrics", nil)
 	recorder := httptest.NewRecorder()
@@ -34,4 +40,10 @@ func TestPrometheusHandlerExposesFullSyncProgressMetrics(t *testing.T) {
 	assert.Contains(t, body, `full_sync_collections_finished{name="rs-full-metrics",stage="full"} 1`, "should be equal")
 	assert.Contains(t, body, `full_sync_collections_processing{name="rs-full-metrics",stage="full"} 1`, "should be equal")
 	assert.Contains(t, body, `full_sync_collections_waiting{name="rs-full-metrics",stage="full"} 0`, "should be equal")
+	assert.Contains(t, body, `full_sync_collections_progress_ratio{name="rs-full-metrics",stage="full"} 0.5`, "should be equal")
+	assert.Contains(t, body, `full_sync_collection_status{collection="users",db="db1",name="rs-full-metrics",stage="full"} 2`, "should be equal")
+	assert.Contains(t, body, `full_sync_collection_docs_total{collection="users",db="db1",name="rs-full-metrics",stage="full"} 100`, "should be equal")
+	assert.Contains(t, body, `full_sync_collection_docs_finished{collection="users",db="db1",name="rs-full-metrics",stage="full"} 25`, "should be equal")
+	assert.Contains(t, body, `full_sync_collection_progress_ratio{collection="users",db="db1",name="rs-full-metrics",stage="full"} 1`, "should be equal")
+	assert.Contains(t, body, `full_sync_collection_status{collection="orders",db="db1",name="rs-full-metrics",stage="full"} 1`, "should be equal")
 }

--- a/collector/persister.go
+++ b/collector/persister.go
@@ -233,7 +233,11 @@ func (p *Persister) updateBufferUsedMetric() {
 		return
 	}
 
-	utils.PersisterBufferUsedProm.WithLabelValues(p.replset, utils.TypeIncr).Set(float64(len(p.Buffer)))
+	used := len(p.Buffer)
+	capacity := cap(p.Buffer)
+	utils.PersisterBufferUsedProm.WithLabelValues(p.replset, utils.TypeIncr).Set(float64(used))
+	utils.PersisterBufferCapacityProm.WithLabelValues(p.replset, utils.TypeIncr).Set(float64(capacity))
+	utils.PersisterBufferUsedRatioProm.WithLabelValues(p.replset, utils.TypeIncr).Set(utils.QueueUsedRatio(used, capacity))
 }
 
 func (p *Persister) retrieve() {

--- a/collector/syncer.go
+++ b/collector/syncer.go
@@ -590,11 +590,12 @@ func (sync *OplogSyncer) updatePendingQueueMetric(index int) {
 		return
 	}
 
-	utils.PendingQueueUsedProm.WithLabelValues(
-		sync.Replset,
-		utils.TypeIncr,
-		strconv.Itoa(index),
-	).Set(float64(len(sync.PendingQueue[index])))
+	used := len(sync.PendingQueue[index])
+	capacity := cap(sync.PendingQueue[index])
+	labels := []string{sync.Replset, utils.TypeIncr, strconv.Itoa(index)}
+	utils.PendingQueueUsedProm.WithLabelValues(labels...).Set(float64(used))
+	utils.PendingQueueCapacityProm.WithLabelValues(labels...).Set(float64(capacity))
+	utils.PendingQueueUsedRatioProm.WithLabelValues(labels...).Set(utils.QueueUsedRatio(used, capacity))
 }
 
 func (sync *OplogSyncer) updateLogsQueueMetric(index int) {
@@ -602,11 +603,12 @@ func (sync *OplogSyncer) updateLogsQueueMetric(index int) {
 		return
 	}
 
-	utils.LogsQueueUsedProm.WithLabelValues(
-		sync.Replset,
-		utils.TypeIncr,
-		strconv.Itoa(index),
-	).Set(float64(len(sync.logsQueue[index])))
+	used := len(sync.logsQueue[index])
+	capacity := cap(sync.logsQueue[index])
+	labels := []string{sync.Replset, utils.TypeIncr, strconv.Itoa(index)}
+	utils.LogsQueueUsedProm.WithLabelValues(labels...).Set(float64(used))
+	utils.LogsQueueCapacityProm.WithLabelValues(labels...).Set(float64(capacity))
+	utils.LogsQueueUsedRatioProm.WithLabelValues(labels...).Set(utils.QueueUsedRatio(used, capacity))
 }
 
 func (sync *OplogSyncer) recordLastFetchStats(logs []*oplog.GenericOplog, now time.Time) {

--- a/collector/worker.go
+++ b/collector/worker.go
@@ -295,11 +295,12 @@ func (worker *Worker) updateJobsQueuedMetric() {
 		return
 	}
 
-	utils.WorkerJobsQueuedProm.WithLabelValues(
-		worker.syncer.Replset,
-		utils.TypeIncr,
-		strconv.FormatUint(uint64(worker.id), 10),
-	).Set(float64(len(worker.queue)))
+	used := len(worker.queue)
+	capacity := cap(worker.queue)
+	labels := []string{worker.syncer.Replset, utils.TypeIncr, strconv.FormatUint(uint64(worker.id), 10)}
+	utils.WorkerJobsQueuedProm.WithLabelValues(labels...).Set(float64(used))
+	utils.WorkerJobsQueueCapacityProm.WithLabelValues(labels...).Set(float64(capacity))
+	utils.WorkerJobsQueueUsedRatioProm.WithLabelValues(labels...).Set(utils.QueueUsedRatio(used, capacity))
 }
 
 func (worker *Worker) updateUnackBufferMetric() {

--- a/common/http.go
+++ b/common/http.go
@@ -27,9 +27,13 @@ type PrometheusProvider struct {
 }
 
 func PrometheusInitHttpApi(port int) {
+	PrometheusInitHttpApiWithName(port, "collector")
+}
+
+func PrometheusInitHttpApiWithName(port int, name string) {
 	PrometheusHttpApi = &PrometheusProvider{
 		port:    port,
-		handler: PrometheusHandler(),
+		handler: PrometheusHandlerWithName(name),
 	}
 }
 

--- a/common/metric.go
+++ b/common/metric.go
@@ -104,6 +104,9 @@ func (metric *ReplicationMetric) init() {
 
 func (metric *ReplicationMetric) Close() {
 	metric.isClosed = true
+	if metric.STAGE == TypeIncr {
+		SetMongoShakeSyncState(metric.NAME, metric.STAGE, SyncStateStopped)
+	}
 }
 
 func (metric *ReplicationMetric) String() string {
@@ -137,6 +140,7 @@ func (metric *ReplicationMetric) startup() {
 			lsnCkpt := atomic.LoadInt64(&metric.LSNCheckpoint)
 			restrans := atomic.LoadUint64(&metric.Retransmission)
 			tps := atomic.LoadUint64(&metric.OplogSuccess.Delta)
+			OplogSuccessTpsProm.WithLabelValues(metric.NAME, metric.STAGE).Set(float64(tps))
 			success := atomic.LoadUint64(&metric.OplogSuccess.Value)
 
 			verbose := "[name=%s, stage=%s, get=%d"
@@ -192,16 +196,13 @@ func (metric *ReplicationMetric) getTunnelTraffic() string {
 }
 
 func (metric *ReplicationMetric) initPrometheusSeries() {
-	if metric.STAGE != TypeIncr {
-		return
-	}
-
 	counterLabels := []string{metric.NAME, metric.STAGE}
 	OplogFilterProm.WithLabelValues(counterLabels...).Add(0)
 	OplogGetProm.WithLabelValues(counterLabels...).Add(0)
 	OplogConsumeProm.WithLabelValues(counterLabels...).Add(0)
 	OplogApplyProm.WithLabelValues(counterLabels...).Add(0)
 	OplogSuccessProm.WithLabelValues(counterLabels...).Add(0)
+	OplogSuccessTpsProm.WithLabelValues(counterLabels...).Set(0)
 	OplogFailProm.WithLabelValues(counterLabels...).Add(0)
 	CheckpointTimesProm.WithLabelValues(counterLabels...).Add(0)
 	RetransmissionProm.WithLabelValues(counterLabels...).Add(0)
@@ -218,6 +219,7 @@ func (metric *ReplicationMetric) initPrometheusSeries() {
 	ReplStatusCodeProm.WithLabelValues(gaugeLabels...).Set(0)
 	LSNAckLagSecondsProm.WithLabelValues(gaugeLabels...).Set(0)
 	LSNCheckpointLagSecondsProm.WithLabelValues(gaugeLabels...).Set(0)
+	MongoShakeSyncStateCodeProm.WithLabelValues(metric.NAME, metric.STAGE).Set(float64(SyncStateInit))
 }
 
 func (metric *ReplicationMetric) Get() uint64 {

--- a/common/metric_prom.go
+++ b/common/metric_prom.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"net/http"
+	"runtime"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -10,8 +12,9 @@ import (
 )
 
 var (
-	prometheusRegistry = prometheus.NewRegistry()
-	prometheusInitOnce sync.Once
+	prometheusRegistry  = prometheus.NewRegistry()
+	prometheusInitOnce  sync.Once
+	prometheusStartTime = time.Now()
 )
 
 var OplogFilterProm = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -37,6 +40,11 @@ var OplogApplyProm = prometheus.NewCounterVec(prometheus.CounterOpts{
 var OplogSuccessProm = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name: "oplog_success_total",
 	Help: "Total number of successfully acknowledged oplogs.",
+}, []string{"name", "stage"})
+
+var OplogSuccessTpsProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "oplog_success_tps",
+	Help: "Current successful oplog throughput per second, matching the internal metric delta.",
 }, []string{"name", "stage"})
 
 var OplogFailProm = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -124,14 +132,44 @@ var PendingQueueUsedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Current used size of the pending queue.",
 }, []string{"name", "stage", "queue_id"})
 
+var PendingQueueCapacityProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "pending_queue_capacity",
+	Help: "Capacity of the pending queue.",
+}, []string{"name", "stage", "queue_id"})
+
+var PendingQueueUsedRatioProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "pending_queue_used_ratio",
+	Help: "Current used ratio of the pending queue, from 0 to 1.",
+}, []string{"name", "stage", "queue_id"})
+
 var LogsQueueUsedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "logs_queue_used",
 	Help: "Current used size of the logs queue.",
 }, []string{"name", "stage", "queue_id"})
 
+var LogsQueueCapacityProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "logs_queue_capacity",
+	Help: "Capacity of the logs queue.",
+}, []string{"name", "stage", "queue_id"})
+
+var LogsQueueUsedRatioProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "logs_queue_used_ratio",
+	Help: "Current used ratio of the logs queue, from 0 to 1.",
+}, []string{"name", "stage", "queue_id"})
+
 var WorkerJobsQueuedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "worker_jobs_queued",
 	Help: "Current number of jobs queued in a worker.",
+}, []string{"name", "stage", "worker_id"})
+
+var WorkerJobsQueueCapacityProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "worker_jobs_queue_capacity",
+	Help: "Capacity of a worker jobs queue.",
+}, []string{"name", "stage", "worker_id"})
+
+var WorkerJobsQueueUsedRatioProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "worker_jobs_queue_used_ratio",
+	Help: "Current used ratio of a worker jobs queue, from 0 to 1.",
 }, []string{"name", "stage", "worker_id"})
 
 var WorkerUnackBufferUsedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -142,6 +180,16 @@ var WorkerUnackBufferUsedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 var PersisterBufferUsedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "persister_buffer_used",
 	Help: "Current number of oplogs buffered inside the persister.",
+}, []string{"name", "stage"})
+
+var PersisterBufferCapacityProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "persister_buffer_capacity",
+	Help: "Capacity of the persister in-memory buffer.",
+}, []string{"name", "stage"})
+
+var PersisterBufferUsedRatioProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "persister_buffer_used_ratio",
+	Help: "Current used ratio of the persister in-memory buffer, from 0 to 1.",
 }, []string{"name", "stage"})
 
 var FullSyncCollectionsTotalProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -164,6 +212,56 @@ var FullSyncCollectionsWaitingProm = prometheus.NewGaugeVec(prometheus.GaugeOpts
 	Help: "Number of collections waiting to start during full sync.",
 }, []string{"name", "stage"})
 
+var FullSyncCollectionsProgressRatioProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "full_sync_collections_progress_ratio",
+	Help: "Overall full sync collection progress ratio, from 0 to 1.",
+}, []string{"name", "stage"})
+
+var FullSyncCollectionStatusProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "full_sync_collection_status",
+	Help: "Full sync collection status code: 0 wait start, 1 processing, 2 finish.",
+}, []string{"name", "stage", "db", "collection"})
+
+var FullSyncCollectionDocsTotalProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "full_sync_collection_docs_total",
+	Help: "Total number of documents discovered for a collection during full sync.",
+}, []string{"name", "stage", "db", "collection"})
+
+var FullSyncCollectionDocsFinishedProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "full_sync_collection_docs_finished",
+	Help: "Number of documents finished for a collection during full sync.",
+}, []string{"name", "stage", "db", "collection"})
+
+var FullSyncCollectionProgressRatioProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "full_sync_collection_progress_ratio",
+	Help: "Full sync collection document progress ratio, from 0 to 1.",
+}, []string{"name", "stage", "db", "collection"})
+
+var MongoShakeSyncStageProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "mongoshake_sync_stage",
+	Help: "Current MongoShake sync stage. 1 means active, 0 means inactive.",
+}, []string{"name", "stage"})
+
+var MongoShakeSyncStageStartTimeProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "mongoshake_sync_stage_start_time_seconds",
+	Help: "Unix timestamp when the current sync stage started.",
+}, []string{"name", "stage"})
+
+var MongoShakeSyncStateCodeProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "mongoshake_sync_state_code",
+	Help: "MongoShake sync state code: 0 init, 1 running, 2 done, 3 error, 4 stopped.",
+}, []string{"name", "stage"})
+
+var MongoShakeInfoProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "mongoshake_info",
+	Help: "MongoShake build and runtime information.",
+}, []string{"name", "version", "go_version"})
+
+var MongoShakeUptimeSecondsProm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "mongoshake_uptime_seconds",
+	Help: "MongoShake process uptime in seconds observed by the Prometheus handler.",
+}, []string{"name"})
+
 var ExecutorOperationsProm = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name: "executor_op_total",
 	Help: "Total number of direct executor operations grouped by operation type.",
@@ -173,11 +271,13 @@ func InitPrometheus() {
 	prometheusInitOnce.Do(func() {
 		prometheusRegistry.MustRegister(
 			collectors.NewGoCollector(),
+			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 			OplogFilterProm,
 			OplogGetProm,
 			OplogConsumeProm,
 			OplogApplyProm,
 			OplogSuccessProm,
+			OplogSuccessTpsProm,
 			OplogFailProm,
 			OplogWriteFailProm,
 			CheckpointTimesProm,
@@ -195,20 +295,80 @@ func InitPrometheus() {
 			LSNAckLagSecondsProm,
 			LSNCheckpointLagSecondsProm,
 			PendingQueueUsedProm,
+			PendingQueueCapacityProm,
+			PendingQueueUsedRatioProm,
 			LogsQueueUsedProm,
+			LogsQueueCapacityProm,
+			LogsQueueUsedRatioProm,
 			WorkerJobsQueuedProm,
+			WorkerJobsQueueCapacityProm,
+			WorkerJobsQueueUsedRatioProm,
 			WorkerUnackBufferUsedProm,
 			PersisterBufferUsedProm,
+			PersisterBufferCapacityProm,
+			PersisterBufferUsedRatioProm,
 			FullSyncCollectionsTotalProm,
 			FullSyncCollectionsFinishedProm,
 			FullSyncCollectionsProcessingProm,
 			FullSyncCollectionsWaitingProm,
+			FullSyncCollectionsProgressRatioProm,
+			FullSyncCollectionStatusProm,
+			FullSyncCollectionDocsTotalProm,
+			FullSyncCollectionDocsFinishedProm,
+			FullSyncCollectionProgressRatioProm,
 			ExecutorOperationsProm,
+			MongoShakeSyncStageProm,
+			MongoShakeSyncStageStartTimeProm,
+			MongoShakeSyncStateCodeProm,
+			MongoShakeInfoProm,
+			MongoShakeUptimeSecondsProm,
 		)
 	})
 }
 
 func PrometheusHandler() http.Handler {
 	InitPrometheus()
-	return promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{})
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ObserveMongoShakeUptime("collector")
+		promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	})
+}
+
+const (
+	SyncStateInit uint64 = iota
+	SyncStateRunning
+	SyncStateDone
+	SyncStateError
+	SyncStateStopped
+)
+
+func SetMongoShakeSyncStage(name string, activeStage string) {
+	now := float64(time.Now().Unix())
+	for _, stage := range []string{TypeFull, TypeIncr} {
+		value := 0.0
+		if stage == activeStage {
+			value = 1
+			MongoShakeSyncStageStartTimeProm.WithLabelValues(name, stage).Set(now)
+		}
+		MongoShakeSyncStageProm.WithLabelValues(name, stage).Set(value)
+	}
+}
+
+func SetMongoShakeSyncState(name, stage string, state uint64) {
+	MongoShakeSyncStateCodeProm.WithLabelValues(name, stage).Set(float64(state))
+}
+
+func SetMongoShakeInfo(name string) {
+	MongoShakeInfoProm.WithLabelValues(name, BRANCH, runtime.Version()).Set(1)
+}
+
+func ObserveMongoShakeUptime(name string) {
+	MongoShakeUptimeSecondsProm.WithLabelValues(name).Set(time.Since(prometheusStartTime).Seconds())
+}
+
+func QueueUsedRatio(used, capacity int) float64 {
+	if capacity <= 0 {
+		return 0
+	}
+	return float64(used) / float64(capacity)
 }

--- a/common/metric_prom.go
+++ b/common/metric_prom.go
@@ -327,9 +327,13 @@ func InitPrometheus() {
 }
 
 func PrometheusHandler() http.Handler {
+	return PrometheusHandlerWithName("collector")
+}
+
+func PrometheusHandlerWithName(name string) http.Handler {
 	InitPrometheus()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ObserveMongoShakeUptime("collector")
+		ObserveMongoShakeUptime(name)
 		promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
 	})
 }

--- a/common/metric_prom_test.go
+++ b/common/metric_prom_test.go
@@ -64,13 +64,13 @@ func TestPrometheusHandlerExposesZeroValueMetricsForFreshIncrMetric(t *testing.T
 func TestPrometheusHandlerExposesRuntimeCollectors(t *testing.T) {
 	request := httptest.NewRequest("GET", "/metrics", nil)
 	recorder := httptest.NewRecorder()
-	PrometheusHandler().ServeHTTP(recorder, request)
+	PrometheusHandlerWithName("rs-runtime").ServeHTTP(recorder, request)
 
 	body := recorder.Body.String()
 	assert.Equal(t, 200, recorder.Code, "should be equal")
 	assert.Contains(t, body, `go_info`, "should be equal")
 	assert.Contains(t, body, `go_goroutines`, "should be equal")
-	assert.Contains(t, body, `mongoshake_uptime_seconds{name="collector"}`, "should be equal")
+	assert.Contains(t, body, `mongoshake_uptime_seconds{name="rs-runtime"}`, "should be equal")
 }
 
 func TestPrometheusHandlerExposesSyncStageAndInfoMetrics(t *testing.T) {

--- a/common/metric_prom_test.go
+++ b/common/metric_prom_test.go
@@ -58,6 +58,7 @@ func TestPrometheusHandlerExposesZeroValueMetricsForFreshIncrMetric(t *testing.T
 	assert.Contains(t, body, `oplog_fail_total{name="rs-prom-zero",stage="incr"} 0`, "should be equal")
 	assert.Contains(t, body, `retransmission_total{name="rs-prom-zero",stage="incr"} 0`, "should be equal")
 	assert.Contains(t, body, `checkpoint_times_total{name="rs-prom-zero",stage="incr"} 0`, "should be equal")
+	assert.Contains(t, body, `oplog_success_tps{name="rs-prom-zero",stage="incr"} 0`, "should be equal")
 }
 
 func TestPrometheusHandlerExposesRuntimeCollectors(t *testing.T) {
@@ -69,4 +70,29 @@ func TestPrometheusHandlerExposesRuntimeCollectors(t *testing.T) {
 	assert.Equal(t, 200, recorder.Code, "should be equal")
 	assert.Contains(t, body, `go_info`, "should be equal")
 	assert.Contains(t, body, `go_goroutines`, "should be equal")
+	assert.Contains(t, body, `mongoshake_uptime_seconds{name="collector"}`, "should be equal")
+}
+
+func TestPrometheusHandlerExposesSyncStageAndInfoMetrics(t *testing.T) {
+	SetMongoShakeInfo("rs-stage")
+	SetMongoShakeSyncStage("rs-stage", TypeFull)
+	SetMongoShakeSyncState("rs-stage", TypeFull, SyncStateRunning)
+
+	request := httptest.NewRequest("GET", "/metrics", nil)
+	recorder := httptest.NewRecorder()
+	PrometheusHandler().ServeHTTP(recorder, request)
+
+	body := recorder.Body.String()
+	assert.Equal(t, 200, recorder.Code, "should be equal")
+	assert.Contains(t, body, `mongoshake_sync_stage{name="rs-stage",stage="full"} 1`, "should be equal")
+	assert.Contains(t, body, `mongoshake_sync_stage{name="rs-stage",stage="incr"} 0`, "should be equal")
+	assert.Contains(t, body, `mongoshake_sync_state_code{name="rs-stage",stage="full"} 1`, "should be equal")
+	assert.Contains(t, body, `mongoshake_sync_stage_start_time_seconds{name="rs-stage",stage="full"}`, "should be equal")
+	assert.Contains(t, body, `mongoshake_info{`, "should be equal")
+	assert.Contains(t, body, `name="rs-stage"`, "should be equal")
+}
+
+func TestQueueUsedRatio(t *testing.T) {
+	assert.Equal(t, 0.0, QueueUsedRatio(1, 0), "should be equal")
+	assert.Equal(t, 0.25, QueueUsedRatio(1, 4), "should be equal")
 }

--- a/docs/monitor/README.md
+++ b/docs/monitor/README.md
@@ -455,3 +455,107 @@ curl -g 'http://127.0.0.1:9090/api/v1/query?query=up{job="mongoshake"}'
 4. 启动 Grafana，创建 Prometheus datasource
 5. 导入 `docs/monitor/mongoshake-dashboard.json`
 6. 在 dashboard 顶部选择 `Instance`，检查复制状态和 delay 面板是否出数
+
+## 10. 增强指标与常用 PromQL
+
+### 10.1 当前同步阶段
+
+`mongoshake_sync_stage{name,stage}` 用于直接判断当前任务处于全量还是增量阶段：
+
+```promql
+# 当前正在全量同步
+mongoshake_sync_stage{stage="full"} == 1
+
+# 当前正在增量同步
+mongoshake_sync_stage{stage="incr"} == 1
+```
+
+`mongoshake_sync_stage_start_time_seconds{name,stage}` 表示阶段开始时间，可计算阶段持续时间：
+
+```promql
+# 当前全量阶段持续秒数
+time() - mongoshake_sync_stage_start_time_seconds{stage="full"}
+```
+
+`mongoshake_sync_state_code{name,stage}` 表示阶段生命周期状态：
+
+| code | 状态 |
+| --- | --- |
+| 0 | init |
+| 1 | running |
+| 2 | done |
+| 3 | error |
+| 4 | stopped |
+
+### 10.2 全量同步表级进度
+
+以下指标可用于确认具体库表的全量同步进度：
+
+| 指标 | 说明 |
+| --- | --- |
+| `full_sync_collection_status{name,stage,db,collection}` | 表状态：0 等待、1 同步中、2 完成 |
+| `full_sync_collection_docs_total{name,stage,db,collection}` | 表总文档数 |
+| `full_sync_collection_docs_finished{name,stage,db,collection}` | 已完成文档数 |
+| `full_sync_collection_progress_ratio{name,stage,db,collection}` | 表同步进度，范围 0~1 |
+
+常用查询：
+
+```promql
+# 正在同步的表
+full_sync_collection_status{stage="full"} == 1
+
+# 每张表同步百分比
+full_sync_collection_progress_ratio{stage="full"} * 100
+
+# 某个库下每张表同步百分比
+full_sync_collection_progress_ratio{stage="full",db="db1"} * 100
+
+# 未完成的表
+full_sync_collection_progress_ratio{stage="full"} < 1
+```
+
+整体集合进度可用：
+
+```promql
+full_sync_collections_progress_ratio{stage="full"} * 100
+```
+
+### 10.3 队列利用率
+
+新增 capacity 和 ratio 指标，便于观察堆积：
+
+```promql
+pending_queue_used_ratio{stage="incr"}
+logs_queue_used_ratio{stage="incr"}
+worker_jobs_queue_used_ratio{stage="incr"}
+persister_buffer_used_ratio{stage="incr"}
+```
+
+示例告警条件：
+
+```promql
+pending_queue_used_ratio{stage="incr"} > 0.8
+```
+
+### 10.4 TPS 与运行信息
+
+`oplog_success_tps{name,stage}` 暴露内部每秒成功量，和日志中的 `tps` 语义一致。也可以继续使用 counter 计算平滑速率：
+
+```promql
+rate(oplog_success_total[1m])
+```
+
+运行信息：
+
+```promql
+mongoshake_info
+mongoshake_uptime_seconds
+```
+
+进程级指标由 Prometheus process collector 暴露，常见指标包括：
+
+```promql
+process_resident_memory_bytes
+process_virtual_memory_bytes
+process_start_time_seconds
+```


### PR DESCRIPTION
### 概述

为 MongoShake 同步可观测性新增全面的 Prometheus 指标，包括同步阶段/状态追踪、表级全量同步进度、队列利用率、TPS 实时值和运行时信息。

### 新增指标

| 分类 | 指标 | 说明 |
|------|------|------|
| **同步阶段** | `mongoshake_sync_stage` | 当前活跃阶段：full=1 / incr=0 |
| | `mongoshake_sync_stage_start_time_seconds` | 当前阶段开始的 Unix 时间戳 |
| | `mongoshake_sync_state_code` | 生命周期状态：0 初始化、1 运行中、2 完成、3 错误、4 已停止 |
| **全量同步进度** | `full_sync_collections_progress_ratio` | 整体集合级进度（0–1） |
| | `full_sync_collection_status` | 表状态：0 等待、1 同步中、2 完成 |
| | `full_sync_collection_docs_total` | 表总文档数 |
| | `full_sync_collection_docs_finished` | 表已完成文档数 |
| | `full_sync_collection_progress_ratio` | 表文档同步进度（0–1） |
| **队列利用率** | `pending_queue_capacity` / `pending_queue_used_ratio` | Pending 队列容量与使用率 |
| | `logs_queue_capacity` / `logs_queue_used_ratio` | Logs 队列容量与使用率 |
| | `worker_jobs_queue_capacity` / `worker_jobs_queue_used_ratio` | Worker 队列容量与使用率 |
| | `persister_buffer_capacity` / `persister_buffer_used_ratio` | Persister 缓冲区容量与使用率 |
| **TPS 与运行时** | `oplog_success_tps` | 实时成功 oplog TPS |
| | `mongoshake_info` | 构建信息（version, go_version） |
| | `mongoshake_uptime_seconds` | 进程运行时长（秒） |

### 主要改动

- **`common/metric_prom.go`**：注册所有新增指标，添加辅助函数（`SetMongoShakeSyncStage`、`SetMongoShakeSyncState`、`SetMongoShakeInfo`、`ObserveMongoShakeUptime`、`QueueUsedRatio`），注册 `ProcessCollector`
- **`common/metric.go`**：从已有 TPS delta 暴露 `oplog_success_tps`；metric 关闭时设置 `SyncStateStopped`；全量阶段也初始化 Prometheus 指标序列（之前仅增量阶段初始化）
- **`collector/coordinator/full.go`**：全量阶段设置同步阶段/状态，支持 error 与 panic 传播
- **`collector/coordinator/incr.go`**：增量阶段设置同步阶段/状态，支持 error 与 panic 传播
- **`collector/docsyncer/doc_syncer.go`**：追踪表级进度（`updateSingleCollectionProgressMetric`、`addCollectionFinishedDocs`），输出整体进度比
- **`collector/docsyncer/metric.go`**：新增 `StatusCode()` 和 `ProgressRatio()` 方法，使用 atomic 读取
- **`collector/syncer.go` / `worker.go` / `persister.go`**：在原有队列 used 指标基础上，同步输出 capacity 和 used ratio
- **`docs/monitor/README.md`**：文档化所有新增指标及 PromQL 示例
- **测试**：新增和更新同步阶段指标、全量同步进度、队列利用率、运行时等测试用例

### 兼容性

无破坏性变更。所有新增指标均为增量添加，已有指标名称和标签不变。