### PR TITLE
bugfix: route change stream replace events to ReplaceOne instead of $set update (regression of #867)

### DIFF
--- a/oplog/change_stream_event.go
+++ b/oplog/change_stream_event.go
@@ -240,7 +240,8 @@ func ConvertEvent2Oplog(input []byte, fullDoc bool) (*PartialLog, error) {
 		oplog.Namespace = fmt.Sprintf("%s.%s", ns["db"], ns["coll"])
 		oplog.Operation = "u"
 		oplog.Query = event.DocumentKey
-		oplog.Object = bson.D{bson.E{Key: "$set", Value: event.FullDocument}}
+		// pass FullDocument as-is so the executor routes it to ReplaceOne, not a $set update
+		oplog.Object = event.FullDocument
 	case "update":
 		/*
 		 * PRIMARY> db.test.find()

--- a/oplog/change_stream_event_test.go
+++ b/oplog/change_stream_event_test.go
@@ -379,7 +379,13 @@ func runOplog(data *PartialLog) error {
 		_, err := client.Database(ns[0]).Collection(ns[1]).DeleteOne(context.Background(), data.Object)
 		return err
 	case "u":
-		_, err := client.Database(ns[0]).Collection(ns[1]).UpdateOne(context.Background(), data.Query, data.Object)
+		coll := client.Database(ns[0]).Collection(ns[1])
+		// mirror the executor: $-less object is a full-document replace
+		if FindFiledPrefix(data.Object, "$") {
+			_, err := coll.UpdateOne(context.Background(), data.Query, data.Object)
+			return err
+		}
+		_, err := coll.ReplaceOne(context.Background(), data.Query, data.Object)
 		return err
 	case "c":
 		operation, found := ExtraCommandName(data.Object)
@@ -550,6 +556,53 @@ func TestConvertEvent2Oplog(t *testing.T) {
 		assert.Equal(t, 2, len(all), "should be equal")
 		assert.Equal(t, "1", all["1"]["a"], "should be equal")
 		assert.Equal(t, "20", all["2"]["a"], "should be equal")
+	}
+
+	// test replace removes fields absent from FullDocument
+	{
+		fmt.Printf("TestConvertEvent2Oplog case %d.\n", nr)
+		nr++
+
+		var err error
+		client, err = newMongoClient(testUrl)
+		assert.Equal(t, nil, err, "should be equal")
+
+		err = client.Database("testDb").Drop(context.Background())
+		assert.Equal(t, nil, err, "should be equal")
+
+		eventInsert := Event{
+			OperationType: "insert",
+			FullDocument: bson.D{
+				bson.E{Key: "_id", Value: "3"},
+				bson.E{Key: "a", Value: "1"},
+				bson.E{Key: "extra", Value: "keepme"},
+			},
+			Ns: bson.M{"db": "testDb", "coll": "testColl"},
+		}
+		out, err := bson.Marshal(eventInsert)
+		assert.Equal(t, nil, err, "should be equal")
+		err = runByte(out)
+		assert.Equal(t, nil, err, "should be equal")
+
+		eventReplace := Event{
+			OperationType: "replace",
+			DocumentKey:   bson.D{{"_id", "3"}},
+			FullDocument: bson.D{
+				bson.E{Key: "_id", Value: "3"},
+				bson.E{Key: "a", Value: "2"},
+			},
+			Ns: bson.M{"db": "testDb", "coll": "testColl"},
+		}
+		out, err = bson.Marshal(eventReplace)
+		assert.Equal(t, nil, err, "should be equal")
+		err = runByte(out)
+		assert.Equal(t, nil, err, "should be equal")
+
+		all := getAllDoc("testDb", "testColl")
+		assert.Equal(t, 1, len(all), "should be equal")
+		assert.Equal(t, "2", all["3"]["a"], "should be equal")
+		_, hasExtra := all["3"]["extra"]
+		assert.Equal(t, false, hasExtra, "replace must remove fields absent from FullDocument")
 	}
 
 	// test insert & update & delete


### PR DESCRIPTION
  ## Summary

  In incremental sync with `incr_sync.mongo_fetch_method = change_stream`, a `replace` change event is converted into an update oplog whose object is wrapped in `$set`:

```go
  // oplog/change_stream_event.go  (case "replace")
  oplog.Object = bson.D{bson.E{Key: "$set", Value: event.FullDocument}}
```
Because the object begins with $, the executor's doUpdate (FindFiledPrefix(o, "$") == true) issues an UpdateOne with $set instead of a ReplaceOne. A replace must replace the whole document, so this is wrong:

  - Fields present on the target but absent from the source post-image are never removed → source and target silently diverge.
  - The $set payload also contains _id; depending on server version / write path this can additionally raise the immutable-_id error (see #867 ) .

  This is a regression. #867 already fixed this for v2.8.6 by passing FullDocument through, but commit 810acbf (#936, v2.8.7) reverted the replace case back to $set.

  ## Reproduction

  incr_sync.mongo_fetch_method = change_stream, then on the source:

  db.c.insertOne({ _id: 1, a: 1, follow_meta: { x: 1 } })
  db.c.replaceOne({ _id: 1 }, { a: 2 })            // follow_meta removed on source

  Target after sync (wrong - follow_meta should be gone):

  { _id: 1, a: 2, follow_meta: { x: 1 } }

  ## Root cause / history

  - f6a0a38 "support replace in incr sync" - the executor's doUpdate already routes a $-less op:"u" object to ReplaceOne (the intended design).
  - #867 / f2b5d07 (v2.8.6) - both the replace case and the update + watch_full_document case set oplog.Object = event.FullDocument (correct).
  - 810acbf (#936, v2.8.7, "handle 'update document must contain key beginning with '$'' error") - reverted only the replace case to {$set: FullDocument}. 
  The update + watch_full_document branch was left as FullDocument, so the two are now inconsistent.

  The "update document must contain key beginning with '$'" error that 810acbf aimed to fix does not come from the production executor (which already routes a $-less op:"u" to ReplaceOne). 
  It originates in the unit-test helper runOplog in oplog/change_stream_event_test.go, whose case "u" calls UpdateOne(Query, Object) unconditionally - unlike the real executor. So 810acbf changed production code to satisfy a test helper that does not mirror production.

  ## Affected versions

  - Broken: v2.8.4, v2.8.5 (original $set), and again v2.8.7, v2.8.8 (regression).
  - Correct: v2.8.6 only.
  - Only change_stream fetch mode. oplog fetch mode is unaffected.

  ## Changes

  1. oplog/change_stream_event.go, case "replace": pass event.FullDocument as-is so the executor routes it to ReplaceOne (re-applies #867; consistent with the update + watch_full_document branch).
  2. oplog/change_stream_event_test.go: make the runOplog case "u" helper mirror the executor (ReplaceOne when the object has no $ operator), and add a regression test asserting a replace removes fields absent from FullDocument.