### PR TITLE
fix: DDL and DML execution order race condition

### DIFF
--- a/collector/batcher.go
+++ b/collector/batcher.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"strings"
+	"sync/atomic"
 	"time"
 
 	nimo "github.com/gugemichael/nimo4go"
@@ -10,6 +12,7 @@ import (
 	conf "github.com/alibaba/MongoShake/v2/collector/configure"
 	"github.com/alibaba/MongoShake/v2/collector/filter"
 	utils "github.com/alibaba/MongoShake/v2/common"
+	"github.com/alibaba/MongoShake/v2/executor"
 	"github.com/alibaba/MongoShake/v2/oplog"
 	l "github.com/alibaba/MongoShake/v2/pkg/log"
 )
@@ -36,6 +39,50 @@ var (
 		18, 116, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0,
 	}
 )
+
+// DDLExecutor directly executes DDL on target MongoDB, bypassing the worker pipeline.
+// Only created for direct tunnel. For other tunnels, DDL still goes through worker[0].
+type DDLExecutor struct {
+	conn         *utils.MongoCommunityConn
+	fullFinishTs int64
+}
+
+// NewDDLExecutor creates a DDLExecutor with a direct connection to the target MongoDB.
+func NewDDLExecutor(mongoUrl string, fullFinishTs int64) *DDLExecutor {
+	conn, err := utils.NewMongoCommunityConn(
+		mongoUrl,
+		utils.VarMongoConnectModePrimary,
+		true,
+		utils.ReadWriteConcernDefault,
+		utils.ReadWriteConcernDefault,
+		conf.Options.TunnelMongoSslRootCaFile,
+	)
+	if err != nil {
+		l.Logger.Crashf("create DDL executor connection failed: %v", err)
+	}
+	return &DDLExecutor{conn: conn, fullFinishTs: fullFinishTs}
+}
+
+// Execute runs a DDL command directly on the target MongoDB.
+func (e *DDLExecutor) Execute(log *oplog.PartialLog) error {
+	namespace := log.Namespace
+	dc := strings.SplitN(namespace, ".", 2)
+	database := dc[0]
+	operation, _ := oplog.ExtraCommandName(log.Object)
+	l.Logger.Info("DDLExecutor: directly executing DDL [%s] on db[%s], ts=%v",
+		operation, database, log.Timestamp)
+
+	err := executor.RunCommand(database, operation, log, e.conn.Client)
+	if err != nil {
+		if executor.IgnoreError(err, "c", utils.TimeStampToInt64(log.Timestamp) <= e.fullFinishTs) {
+			l.Logger.Debug("DDLExecutor: ignore DDL error [%v]", err)
+			return nil
+		}
+		return err
+	}
+	l.Logger.Info("DDLExecutor: DDL [%s] executed successfully", operation)
+	return nil
+}
 
 func getTargetDelay() int64 {
 	if utils.IncrSentinelOptions.TargetDelay < 0 {
@@ -85,6 +132,10 @@ type Batcher struct {
 	// transaction buffer
 	txnBuffer *oplog.TxnBuffer
 
+	// ddlExecutor directly executes DDL on target MongoDB, bypassing the worker pipeline.
+	// Only created for direct tunnel. For other tunnels, DDL still goes through worker[0].
+	ddlExecutor *DDLExecutor
+
 	// for ut only
 	utBatchesDelay struct {
 		flag        bool                  // ut enable?
@@ -95,6 +146,13 @@ type Batcher struct {
 
 func NewBatcher(syncer *OplogSyncer, filterList filter.OplogFilterChain,
 	handler OplogHandler, workerGroup []*Worker) *Batcher {
+	// Only create DDL executor for direct tunnel (where DDL ordering matters)
+	var ddlExecutor *DDLExecutor
+	if conf.Options.Tunnel == utils.VarTunnelDirect && len(conf.Options.TunnelAddress) > 0 {
+		ddlExecutor = NewDDLExecutor(conf.Options.TunnelAddress[0],
+			utils.TimeStampToInt64(syncer.fullSyncFinishPosition))
+	}
+
 	return &Batcher{
 		syncer:          syncer,
 		filterList:      filterList,
@@ -103,6 +161,7 @@ func NewBatcher(syncer *OplogSyncer, filterList filter.OplogFilterChain,
 		lastOplog:       fakeOplog,
 		lastFilterOplog: fakeOplog.Parsed,
 		txnBuffer:       oplog.NewBuffer(),
+		ddlExecutor:     ddlExecutor,
 	}
 }
 
@@ -276,14 +335,14 @@ func (batcher *Batcher) getBatchWithDelay() ([]*oplog.GenericOplog, bool) {
  * i d i c u i
  *      | |
  */
-func (batcher *Batcher) BatchMore() (genericOplogs [][]*oplog.GenericOplog, barrier bool, allEmpty bool, exit bool) {
+func (batcher *Batcher) BatchMore() (genericOplogs [][]*oplog.GenericOplog, barrier bool, allEmpty bool, exit bool, ddlOplogs []*oplog.GenericOplog) {
 	// picked raw oplogs and batching in sequence
 	batcher.batchGroup = make([][]*oplog.GenericOplog, len(batcher.workerGroup))
 	if batcher.barrierOplogs == nil {
 		batcher.barrierOplogs = make([]*oplog.GenericOplog, 0)
 	}
 
-	// Have barrier Oplogs to performed
+	// Have barrier Oplogs to performed (transaction with command)
 	if len(batcher.barrierOplogs) > 0 {
 		for _, v := range batcher.barrierOplogs {
 			if batcher.filter(v.Parsed) {
@@ -300,14 +359,14 @@ func (batcher *Batcher) BatchMore() (genericOplogs [][]*oplog.GenericOplog, barr
 		}
 		batcher.barrierOplogs = nil
 
-		return batcher.batchGroup, true, batcher.setLastOplog(), false
+		return batcher.batchGroup, true, batcher.setLastOplog(), false, nil
 	}
 
 	// try to get batch
 	mergeBatch, exit := batcher.getBatchWithDelay()
 
 	if mergeBatch == nil {
-		return batcher.batchGroup, false, batcher.setLastOplog(), exit
+		return batcher.batchGroup, false, batcher.setLastOplog(), exit, nil
 	}
 
 	for i, genericLog := range mergeBatch {
@@ -334,7 +393,7 @@ func (batcher *Batcher) BatchMore() (genericOplogs [][]*oplog.GenericOplog, barr
 
 				allEmpty := batcher.setLastOplog()
 				nimo.AssertTrue(allEmpty == true, "batcher.batchGroup don't be empty")
-				return batcher.batchGroup, true, allEmpty, false
+				return batcher.batchGroup, true, allEmpty, false, nil
 			} else {
 				for _, ele := range deliveredOps {
 					batcher.addIntoBatchGroup(ele, false)
@@ -370,11 +429,12 @@ func (batcher *Batcher) BatchMore() (genericOplogs [][]*oplog.GenericOplog, barr
 		if ddlFilter.Filter(genericLog.Parsed) {
 
 			if conf.Options.FilterDDLEnable {
-				batcher.barrierOplogs = append(batcher.barrierOplogs, genericLog)
+				// DDL is returned via ddlOplogs for direct execution by startBatcher
+				ddlOplogs = append(ddlOplogs, genericLog)
 
 				batcher.remainLogs = mergeBatch[i+1:]
 
-				return batcher.batchGroup, true, batcher.setLastOplog(), false
+				return batcher.batchGroup, true, batcher.setLastOplog(), false, ddlOplogs
 			} else {
 				// filter
 				batcher.syncer.replMetric.AddFilter(1)
@@ -388,7 +448,7 @@ func (batcher *Batcher) BatchMore() (genericOplogs [][]*oplog.GenericOplog, barr
 		batcher.addIntoBatchGroup(genericLog, false)
 	}
 
-	return batcher.batchGroup, false, batcher.setLastOplog(), exit
+	return batcher.batchGroup, false, batcher.setLastOplog(), exit, nil
 }
 
 func (batcher *Batcher) setLastOplog() bool {
@@ -520,4 +580,68 @@ func (batcher *Batcher) moveToNextQueue() {
 
 func (batcher *Batcher) currentQueue() uint64 {
 	return batcher.nextQueue
+}
+
+// waitForAllWorkersIdle waits until all workers have empty queues and all dispatched
+// oplogs have been acknowledged (ack == unack). This ensures all DML operations are
+// completed before DDL execution.
+func (batcher *Batcher) waitForAllWorkersIdle() bool {
+	l.Logger.Info("%s waiting for all workers to be idle (barrier)", batcher.syncer)
+
+	for i := 0; ; i++ {
+		if utils.IncrSentinelOptions.Pause || utils.IncrSentinelOptions.Shutdown {
+			l.Logger.Warn("%s barrier wait interrupted by sentinel (Pause=%v, Shutdown=%v)",
+				batcher.syncer, utils.IncrSentinelOptions.Pause, utils.IncrSentinelOptions.Shutdown)
+			return false
+		}
+
+		allIdle := true
+		for _, worker := range batcher.workerGroup {
+			queueLen := len(worker.queue)
+			ack := atomic.LoadInt64(&worker.ack)
+			unack := atomic.LoadInt64(&worker.unack)
+			if queueLen > 0 || (unack != ack) {
+				allIdle = false
+				break
+			}
+		}
+
+		if allIdle {
+			l.Logger.Info("%s all workers are idle, barrier satisfied", batcher.syncer)
+			return true
+		}
+
+		if i%CheckCheckpointUpdateTimes == 0 {
+			l.Logger.Info("%s[%d] waiting for workers to be idle", batcher.syncer, i)
+		}
+
+		utils.YieldInMs(DDLCheckpointInterval)
+	}
+}
+
+// executeDDLDirectly executes DDL operations directly on the target MongoDB,
+// bypassing the worker pipeline. For direct tunnel, DDL is executed by DDLExecutor.
+// For non-direct tunnel, DDL falls back to being dispatched to worker[0].
+func (batcher *Batcher) executeDDLDirectly(ddlOplogs []*oplog.GenericOplog) error {
+	if batcher.ddlExecutor == nil {
+		// Non-direct tunnel: fall back to dispatching DDL to worker[0]
+		for _, v := range ddlOplogs {
+			batcher.addIntoBatchGroup(v, true)
+		}
+		return nil
+	}
+
+	// Direct tunnel: execute DDL directly, bypassing worker pipeline
+	for _, ddlLog := range ddlOplogs {
+		if batcher.filter(ddlLog.Parsed) {
+			batcher.lastFilterOplog = ddlLog.Parsed
+			continue
+		}
+		if err := batcher.ddlExecutor.Execute(ddlLog.Parsed); err != nil {
+			return err
+		}
+		batcher.syncer.replMetric.AddApply(1)
+		batcher.syncer.replMetric.AddSuccess(1)
+	}
+	return nil
 }

--- a/collector/batcher_test.go
+++ b/collector/batcher_test.go
@@ -753,7 +753,7 @@ func TestBatchMoreApplyOpsInheritsSourceTime(t *testing.T) {
 		},
 	}
 
-	batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+	batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 
 	assert.Equal(t, false, barrier, "should be equal")
 	assert.Equal(t, false, allEmpty, "should be equal")
@@ -823,7 +823,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(6, nil, nil, nil, 100)
 		syncer.logsQueue[2] <- mockOplogs(7, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 18, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -834,7 +834,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		syncer.logsQueue[0] <- mockOplogs(1, nil, nil, nil, 300)
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -861,7 +861,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(6, nil, nil, nil, 100)
 		syncer.logsQueue[2] <- mockOplogs(7, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 11, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -871,7 +871,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(105), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 7, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -882,7 +882,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// test the last flush oplog
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -907,7 +907,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[0] <- mockOplogs(5, []int{0, 1, 2, 3, 4}, nil, nil, 0)
 		syncer.logsQueue[1] <- mockOplogs(6, []int{0, 1, 2, 3, 4, 5}, nil, nil, 100)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -917,7 +917,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -944,7 +944,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(6, []int{2}, nil, nil, 100)
 		syncer.logsQueue[2] <- mockOplogs(7, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 7, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -954,7 +954,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -964,7 +964,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 10, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -974,7 +974,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1001,7 +1001,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(6, []int{2}, nil, nil, 100)
 		syncer.logsQueue[2] <- mockOplogs(7, []int{4, 5}, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1012,7 +1012,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// 3 in logsQ[0]
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1022,7 +1022,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(3), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1033,7 +1033,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// 2 in logsQ[1]
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1043,7 +1043,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 7, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1054,7 +1054,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(203), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// 4 in logsQ[2]
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1065,7 +1065,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// 5 in logsQ[2]
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1075,7 +1075,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1086,7 +1086,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(205), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// test the last flush oplog
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1096,7 +1096,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1123,7 +1123,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(6, nil, nil, nil, 100)
 		syncer.logsQueue[2] <- mockOplogs(7, []int{6}, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1133,7 +1133,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1143,7 +1143,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(0), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 16, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1153,7 +1153,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(205), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1166,7 +1166,7 @@ func TestBatchMore(t *testing.T) {
 		// push again
 		syncer.logsQueue[0] <- mockOplogs(80, nil, nil, nil, 300)
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 80, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1177,7 +1177,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(379), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// test the last flush oplog
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1204,7 +1204,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(1, []int{0}, nil, nil, 100)
 		syncer.logsQueue[2] <- mockOplogs(1, []int{0}, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1214,7 +1214,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1224,7 +1224,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(0), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1234,7 +1234,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(0), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1244,7 +1244,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1254,7 +1254,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1267,7 +1267,7 @@ func TestBatchMore(t *testing.T) {
 		// push again
 		syncer.logsQueue[0] <- mockOplogs(80, nil, nil, nil, 300)
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1277,7 +1277,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1287,7 +1287,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(100), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1297,7 +1297,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(100), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1307,7 +1307,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(200), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 80, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1317,7 +1317,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(379), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1344,7 +1344,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockOplogs(6, []int{5}, nil, nil, 100) // last is ddl
 		syncer.logsQueue[2] <- mockOplogs(7, []int{3}, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 10, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1354,7 +1354,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(104), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1364,7 +1364,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(105), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1374,7 +1374,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(202), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1384,7 +1384,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(203), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1394,7 +1394,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, 0, batcher.txnBuffer.Size(), "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1419,7 +1419,7 @@ func TestBatchMore(t *testing.T) {
 
 		syncer.logsQueue[0] <- mockOplogs(1, nil, nil, []int{0}, 100)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1428,7 +1428,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1437,7 +1437,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(100), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1464,7 +1464,7 @@ func TestBatchMore(t *testing.T) {
 		// at the end of queue
 		syncer.logsQueue[2] <- mockOplogs(7, nil, nil, []int{5, 6}, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1474,7 +1474,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1487,7 +1487,7 @@ func TestBatchMore(t *testing.T) {
 		// inject more
 		syncer.logsQueue[0] <- mockOplogs(5, nil, nil, []int{1}, 300)
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1497,7 +1497,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(13), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1507,7 +1507,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(14), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 11, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1517,7 +1517,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1527,7 +1527,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(205), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1537,7 +1537,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(205), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1547,7 +1547,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1557,7 +1557,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(300), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1567,7 +1567,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(301), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1577,7 +1577,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(304), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1604,7 +1604,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockTxnPartialOplogs(100, false)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1614,7 +1614,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1624,7 +1624,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1634,7 +1634,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1644,7 +1644,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(6), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1654,7 +1654,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(8), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 9, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1664,7 +1664,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1674,7 +1674,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1699,7 +1699,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[0] <- mockOplogs(9, nil, nil, []int{2, 6}, 0)
 		syncer.logsQueue[1] <- mockTxnPartialOplogs(100, false)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1709,7 +1709,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1719,7 +1719,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1729,7 +1729,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1739,7 +1739,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(6), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1749,7 +1749,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(8), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 9, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1759,7 +1759,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1788,7 +1788,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockTxnPartialOplogs(100, true)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1798,7 +1798,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1808,7 +1808,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1818,7 +1818,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1828,7 +1828,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(6), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1838,7 +1838,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 9, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1848,7 +1848,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(103), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1858,7 +1858,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1885,7 +1885,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockDisTxnOplogs(100, false, true)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1895,7 +1895,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1905,7 +1905,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(100), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1915,7 +1915,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1942,7 +1942,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockDisTxnOplogs(100, true, true)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 6, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1952,7 +1952,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1962,7 +1962,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -1972,7 +1972,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -1999,7 +1999,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockDisTxnOplogs(100, false, false)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 10, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2009,7 +2009,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2036,7 +2036,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockDisTxnPartialOplogs(100, false, true)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2046,7 +2046,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 6, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2056,7 +2056,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2066,7 +2066,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2093,7 +2093,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockDisTxnPartialOplogs(100, true, true)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 6, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2103,7 +2103,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 6, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2113,7 +2113,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(102), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2123,7 +2123,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2150,7 +2150,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[1] <- mockDisTxnPartialOplogs(100, true, false)
 		syncer.logsQueue[2] <- mockOplogs(5, nil, nil, nil, 200)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 11, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2160,7 +2160,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(103), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2185,7 +2185,7 @@ func TestBatchMore(t *testing.T) {
 
 		syncer.logsQueue[0] <- mockOplogs(9, nil, []int{3, 4, 7, 8}, []int{2, 6}, 0)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2195,7 +2195,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2205,7 +2205,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2215,7 +2215,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2225,7 +2225,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(6), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2250,7 +2250,7 @@ func TestBatchMore(t *testing.T) {
 
 		syncer.logsQueue[0] <- mockOplogs(9, []int{0, 7}, []int{3, 4}, []int{2, 6}, 0)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2260,7 +2260,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2270,7 +2270,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(0), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2280,7 +2280,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2290,7 +2290,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2300,7 +2300,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2310,7 +2310,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(6), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2320,7 +2320,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(6), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2330,7 +2330,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(7), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2340,7 +2340,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(8), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2369,7 +2369,7 @@ func TestBatchMore(t *testing.T) {
 		syncer.logsQueue[2] <- mockOplogs(8, []int{0}, []int{1, 7}, []int{4, 5, 6}, 200)
 
 		// hit the 4 in logsQ[0]
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2380,7 +2380,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(3), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// after 4 in logsQ[0]
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2390,7 +2390,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2400,7 +2400,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2410,7 +2410,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2420,7 +2420,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2430,7 +2430,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(100), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2440,7 +2440,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(100), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2450,7 +2450,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2460,7 +2460,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(106), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2470,7 +2470,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(106), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(101), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2480,7 +2480,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(106), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(200), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 2, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2490,7 +2490,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(201), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(203), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2500,7 +2500,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(201), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2510,7 +2510,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(201), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(204), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2520,7 +2520,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(201), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(205), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2530,7 +2530,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(201), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(205), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2540,7 +2540,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(201), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(206), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2565,7 +2565,7 @@ func TestBatchMore(t *testing.T) {
 
 		syncer.logsQueue[0] <- mockOplogs(4, []int{2}, []int{0, 1}, nil, 0)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2575,7 +2575,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, fakeOplog, batcher.lastOplog, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2585,7 +2585,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2595,7 +2595,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastFilterOplog.Timestamp, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(3), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2619,7 +2619,7 @@ func TestBatchMore(t *testing.T) {
 
 		syncer.logsQueue[0] <- mockOplogs(6, []int{5}, nil, nil, 0)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2629,7 +2629,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2639,7 +2639,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2663,7 +2663,7 @@ func TestBatchMore(t *testing.T) {
 
 		syncer.logsQueue[0] <- mockOplogs(6, nil, nil, []int{1, 2, 3, 4, 5}, 0)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 1, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2673,7 +2673,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(0), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2683,7 +2683,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2693,7 +2693,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(1), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2703,7 +2703,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2713,7 +2713,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(2), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2723,7 +2723,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(3), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2733,7 +2733,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(3), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2743,7 +2743,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2753,7 +2753,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(4), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, true, barrier, "should be equal")
 		assert.Equal(t, 3, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2763,7 +2763,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, fakeOplog.Parsed, batcher.lastFilterOplog, "should be equal")
 		assert.Equal(t, utils.TimeToTimestamp(5), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2787,7 +2787,7 @@ func TestBatchMore(t *testing.T) {
 
 		// syncer.logsQueue[0] <- mockOplogs(6, nil, nil, []int{1, 2, 3, 4, 5}, 0)
 
-		batchedOplog, barrier, allEmpty, _ := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ := batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2799,7 +2799,7 @@ func TestBatchMore(t *testing.T) {
 
 		// all filtered
 		syncer.logsQueue[0] <- mockOplogs(3, nil, []int{0, 1, 2}, nil, 0)
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")
@@ -2811,7 +2811,7 @@ func TestBatchMore(t *testing.T) {
 
 		// inject one
 		syncer.logsQueue[1] <- mockOplogs(5, nil, nil, nil, 100)
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 5, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, false, allEmpty, "should be equal")
@@ -2822,7 +2822,7 @@ func TestBatchMore(t *testing.T) {
 		assert.Equal(t, utils.TimeToTimestamp(104), batcher.lastOplog.Parsed.Timestamp, "should be equal")
 
 		// get the last one
-		batchedOplog, barrier, allEmpty, _ = batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, _, _ = batcher.BatchMore()
 		assert.Equal(t, false, barrier, "should be equal")
 		assert.Equal(t, 0, len(batchedOplog[0]), "should be equal")
 		assert.Equal(t, true, allEmpty, "should be equal")

--- a/collector/syncer.go
+++ b/collector/syncer.go
@@ -281,7 +281,7 @@ func (sync *OplogSyncer) startBatcher() {
 		// As much as we can batch more from logs queue. batcher can merge
 		// a sort of oplogs from different logs queue one by one. the max number
 		// of oplogs in batch is limited by AdaptiveBatchingMaxSize
-		batchedOplog, barrier, allEmpty, exit := batcher.BatchMore()
+		batchedOplog, barrier, allEmpty, exit, ddlOplogs := batcher.BatchMore()
 
 		// it's better to handle filter in BatchMore function, but I don't want to touch this file anymore
 		if conf.Options.FilterOplogGids {
@@ -312,102 +312,132 @@ func (sync *OplogSyncer) startBatcher() {
 				}
 			}
 
-			// flush checkpoint value
-			sync.checkpoint(true, 0)
-			if !sync.checkCheckpointUpdate(true, newestTs) {
+			// Wait for all workers to complete before exiting
+			if !batcher.waitForAllWorkersIdle() {
 				l.Logger.Warnf("%s exit: barrier wait interrupted, checkpoint may not have reached %v. "+
 					"Not setting CanClose to avoid premature exit", sync, utils.ExtractTimestampForLog(newestTs))
 				pendingBarrierTs = newestTs
 				return
 			}
+			// flush checkpoint value
+			sync.checkpoint(true, newestTs)
 			sync.CanClose = true
 			l.Logger.Infof("%s blocking and waiting exits, checkpoint: %v", sync, utils.ExtractTimestampForLog(newestTs))
 			select {} // block forever, wait outer routine exits
-		} else if log, filterLog := batcher.getLastOplog(); log != nil && !allEmpty {
-			// if all filtered, still update checkpoint
-			newestTs = utils.TimeStampToInt64(log.Timestamp)
+		} else {
+			log, filterLog := batcher.getLastOplog()
 
-			// push to worker
-			if worked := batcher.dispatchBatches(batchedOplog); worked {
-				sync.replMetric.SetLSN(newestTs)
+			// Step 1: DML dispatch (independent of DDL handling)
+			if log != nil && !allEmpty {
+				newestTs = utils.TimeStampToInt64(log.Timestamp)
+
+				// push to worker
+				if worked := batcher.dispatchBatches(batchedOplog); worked {
+					sync.replMetric.SetLSN(newestTs)
+					// update latest fetched timestamp in memory
+					sync.reader.UpdateQueryTimestamp(newestTs)
+				}
+
+				filterFlag = false
+			}
+
+			// Step 2: DDL barrier (independent of DML, because DDL may have no preceding DML)
+			if barrier && len(ddlOplogs) > 0 {
+				// Wait for all workers to complete before executing DDL
+				if !batcher.waitForAllWorkersIdle() {
+					// Wait interrupted by Pause/Shutdown, record barrier and return
+					ddlTs := utils.TimeStampToInt64(ddlOplogs[len(ddlOplogs)-1].Parsed.Timestamp)
+					pendingBarrierTs = ddlTs
+					return
+				}
+				// Execute DDL directly, bypassing worker pipeline
+				if err := batcher.executeDDLDirectly(ddlOplogs); err != nil {
+					l.Logger.Criticalf("%s DDL direct execution failed: %v", sync, err)
+					return
+				}
+				// Update checkpoint after DDL execution
+				ddlTs := utils.TimeStampToInt64(ddlOplogs[len(ddlOplogs)-1].Parsed.Timestamp)
+				sync.checkpoint(true, ddlTs)
+			} else if log != nil && !allEmpty {
+				// No DDL: normal checkpoint update
+				if barrier && conf.Options.Tunnel == utils.VarTunnelDirect {
+					// Direct tunnel: Send() is synchronous blocking, ack is updated when data is persisted
+					// No need to poll checkpoint
+					sync.checkpoint(true, newestTs)
+				} else {
+					sync.checkpoint(barrier, 0)
+					if barrier && !sync.checkCheckpointUpdate(true, newestTs) {
+						pendingBarrierTs = newestTs
+						return
+					}
+				}
+			} else {
+				// if log is nil, check whether filterLog is empty
+				if filterLog == nil {
+					// no need to update
+					l.Logger.Debugf("%s filterLog is nil", sync)
+					return
+				} else if utils.TimeStampToInt64(filterLog.Timestamp) <= sync.ckptManager.GetInMemory().Timestamp {
+					// no need to update
+					l.Logger.Debugf("%s filterLogTs[%v] is small than ckptTs[%v], skip this filterLogTs", sync,
+						filterLog.Timestamp, utils.ExtractTimestampForLog(sync.ckptManager.GetInMemory().Timestamp))
+					return
+				} else {
+					now := time.Now()
+
+					// return if filterFlag == false
+					if filterFlag == false {
+						filterFlag = true
+						filterCheckTs = now
+						return
+					}
+
+					// pass only if all received oplog are filtered for {FilterCheckpointCheckInterval} seconds.
+					if now.After(filterCheckTs.Add(FilterCheckpointCheckInterval*time.Second)) == false {
+						return
+					}
+
+					checkpointTs := utils.ExtractMongoTimestamp(sync.ckptManager.GetInMemory().Timestamp)
+					filterNewestTs := utils.ExtractMongoTimestamp(filterLog.Timestamp)
+					if filterNewestTs-FilterCheckpointGap > checkpointTs {
+						// if checkpoint has not been update for {FilterCheckpointGap} seconds, update
+						// checkpoint mandatory.
+						newestTs = utils.TimeStampToInt64(filterLog.Timestamp)
+						l.Logger.Infof("%s try to update checkpoint mandatory from %v to %v", sync,
+							utils.ExtractTimestampForLog(sync.ckptManager.GetInMemory().Timestamp),
+							filterLog.Timestamp)
+					} else {
+						l.Logger.Debugf("%s filterLogTs[%v] not bigger than checkpoint[%v]",
+							sync, filterLog.Timestamp,
+							utils.ExtractTimestampForLog(sync.ckptManager.GetInMemory().Timestamp))
+						return
+					}
+				}
+
+				filterFlag = false
+
+				if log != nil {
+					newestTsLog := utils.ExtractTimestampForLog(newestTs)
+					if newestTs < utils.TimeStampToInt64(log.Timestamp) {
+						l.Logger.Errorf("%s filter newestTs[%v] smaller than previous timestamp[%v]",
+							sync, newestTsLog, log.Timestamp)
+					}
+
+					l.Logger.Infof("%s waiting last checkpoint[%v] updated", sync, newestTsLog)
+					// check last checkpoint updated
+
+					status := sync.checkCheckpointUpdate(true, utils.TimeStampToInt64(log.Timestamp))
+					l.Logger.Infof("%s last checkpoint[%v] updated [%v]", sync, newestTsLog, status)
+				} else {
+					l.Logger.Infof("%s last log is empty, skip waiting checkpoint updated", sync)
+				}
+
 				// update latest fetched timestamp in memory
 				sync.reader.UpdateQueryTimestamp(newestTs)
-			}
-
-			filterFlag = false
-
-			// flush checkpoint value
-			sync.checkpoint(barrier, 0)
-			if barrier && !sync.checkCheckpointUpdate(true, newestTs) {
-				pendingBarrierTs = newestTs
+				// flush checkpoint by the newest filter oplog value
+				sync.checkpoint(false, newestTs)
 				return
 			}
-		} else {
-			// if log is nil, check whether filterLog is empty
-			if filterLog == nil {
-				// no need to update
-				l.Logger.Debugf("%s filterLog is nil", sync)
-				return
-			} else if utils.TimeStampToInt64(filterLog.Timestamp) <= sync.ckptManager.GetInMemory().Timestamp {
-				// no need to update
-				l.Logger.Debugf("%s filterLogTs[%v] is small than ckptTs[%v], skip this filterLogTs", sync,
-					filterLog.Timestamp, utils.ExtractTimestampForLog(sync.ckptManager.GetInMemory().Timestamp))
-				return
-			} else {
-				now := time.Now()
-
-				// return if filterFlag == false
-				if filterFlag == false {
-					filterFlag = true
-					filterCheckTs = now
-					return
-				}
-
-				// pass only if all received oplog are filtered for {FilterCheckpointCheckInterval} seconds.
-				if now.After(filterCheckTs.Add(FilterCheckpointCheckInterval*time.Second)) == false {
-					return
-				}
-
-				checkpointTs := utils.ExtractMongoTimestamp(sync.ckptManager.GetInMemory().Timestamp)
-				filterNewestTs := utils.ExtractMongoTimestamp(filterLog.Timestamp)
-				if filterNewestTs-FilterCheckpointGap > checkpointTs {
-					// if checkpoint has not been update for {FilterCheckpointGap} seconds, update
-					// checkpoint mandatory.
-					newestTs = utils.TimeStampToInt64(filterLog.Timestamp)
-					l.Logger.Infof("%s try to update checkpoint mandatory from %v to %v", sync,
-						utils.ExtractTimestampForLog(sync.ckptManager.GetInMemory().Timestamp),
-						filterLog.Timestamp)
-				} else {
-					l.Logger.Debugf("%s filterLogTs[%v] not bigger than checkpoint[%v]",
-						sync, filterLog.Timestamp,
-						utils.ExtractTimestampForLog(sync.ckptManager.GetInMemory().Timestamp))
-					return
-				}
-			}
-
-			filterFlag = false
-
-			if log != nil {
-				newestTsLog := utils.ExtractTimestampForLog(newestTs)
-				if newestTs < utils.TimeStampToInt64(log.Timestamp) {
-					l.Logger.Errorf("%s filter newestTs[%v] smaller than previous timestamp[%v]",
-						sync, newestTsLog, log.Timestamp)
-				}
-
-				l.Logger.Infof("%s waiting last checkpoint[%v] updated", sync, newestTsLog)
-				// check last checkpoint updated
-
-				status := sync.checkCheckpointUpdate(true, utils.TimeStampToInt64(log.Timestamp))
-				l.Logger.Infof("%s last checkpoint[%v] updated [%v]", sync, newestTsLog, status)
-			} else {
-				l.Logger.Infof("%s last log is empty, skip waiting checkpoint updated", sync)
-			}
-
-			// update latest fetched timestamp in memory
-			sync.reader.UpdateQueryTimestamp(newestTs)
-			// flush checkpoint by the newest filter oplog value
-			sync.checkpoint(false, newestTs)
-			return
 		}
 	})
 }

--- a/docs/fixes/ddl-barrier-race-condition.md
+++ b/docs/fixes/ddl-barrier-race-condition.md
@@ -1,0 +1,219 @@
+# 修复：DDL 与 DML 执行顺序竞争条件
+
+## 关联
+
+- 继承自：[fix-ddl-barrier-ordering.md](../fix-ddl-barrier-ordering.md)
+- Issue：DDL 和 DML 操作没有按 oplog 顺序同步（部分修复后仍有乱序风险）
+
+## 问题概述
+
+[fix-ddl-barrier-ordering.md](../fix-ddl-barrier-ordering.md) 将 `checkCheckpointUpdate` 的有界循环改为无界循环，解决了"等待超时后继续执行"的问题。但修复不完整，仍存在两种 DDL-DML 乱序场景：
+
+| 场景 | 正常顺序 | Bug 后实际顺序 |
+|------|---------|---------------|
+| **DDL 先于前序 DML 执行** | `DML_1 → DML_2 → DDL → DML_3` | `DDL → DML_1 → DML_2 → DML_3` |
+| **DDL 后于后序 DML 执行** | `DML_1 → DML_2 → DDL → DML_3 → DML_4` | `DML_1 → DML_2 → DML_3 → DML_4 → DDL` |
+
+---
+
+## 根因分析
+
+### 根因 1：`checkCheckpointUpdate` 等待不精确
+
+`checkCheckpointUpdate` 通过比较 `checkpointTs >= newestTs` 来判断 DML 是否执行完成，但这是一种**间接推断**，不精确：
+
+```
+时间线：
+T1: Batcher 解析 DML_1, DML_2
+    → dispatch 到 worker[0], worker[1]
+    → worker.unack 更新（入队即更新）
+    → DML 尚未执行！
+
+T2: Batcher 检测到 DDL
+    → sync.checkCheckpointUpdate(true, newestTs=DML_2.ts)
+
+T3: checkCheckpointUpdate 检查
+    → checkpoint.ts 可能来自之前已完成的操作
+    → 若历史 checkpoint.ts >= newestTs，立即返回 true
+    → ⚠️ 此时 DML_1, DML_2 可能仍在 worker 队列中
+```
+
+**问题本质**：Checkpoint 反映的是**历史已完成操作**的时间戳，而非**当前批次 DML** 是否真正执行完成。存在时间戳乱序场景（如延迟到达的 oplog、历史批次已完成）时，等待会错误地立即成功。
+
+---
+
+### 根因 2：DDL 和 DML 在不同 Worker 中并行执行
+
+DDL 固定发送到 `worker[0]`，DML 按 hash 分布到多个 Worker，各 Worker **并行执行**，执行顺序不确定：
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    Batcher                          │
+│                                                     │
+│  DML_1, DML_2 ──┬──► worker[0] ──► Executor        │
+│                 ├──► worker[1] ──► Executor        │
+│                 └──► worker[N] ──► Executor        │
+│                                                     │
+│  DDL ────────────► worker[0] ──► Executor           │
+│                                                     │
+│  DML_3, DML_4 ──┬──► worker[1] ──► Executor        │
+│                 └──► worker[N] ──► Executor        │
+└─────────────────────────────────────────────────────┘
+
+并行执行，顺序不确定：
+- worker[0] 可能先执行 DDL
+- worker[1] 可能后执行 DML_1
+- 无真正的串行保证
+```
+
+**问题本质**：DDL 和 DML 在不同执行通道中竞争，无法保证 DDL 在"它前面的所有 DML 之后"且"它后面的所有 DML 之前"执行。
+
+---
+
+### 两个根因的关系
+
+| 场景 | 根因 1 的贡献 | 根因 2 的贡献 |
+|------|-------------|-------------|
+| **DDL 先于前序 DML 执行** | 等待立即成功，误判 DML 已完成 | worker[0] 执行 DDL 时，其他 worker 的 DML 还在队列 |
+| **DDL 后于后序 DML 执行** | 等待期间后续 DML 已被 dispatch | DDL dispatch 时机晚于后续 DML，不同 worker 并行 |
+
+---
+
+## 修复方案
+
+### 核心原则
+
+**DDL 不进 Worker 管道，由 Batcher goroutine 直接同步执行。**
+
+Batcher 是单线程的，DDL 在 Batcher 中同步执行即天然串行，永远不会和 DML 并行。
+
+### 修复步骤
+
+```
+1. 检测到 DDL 时，DDL 通过返回值传给 startBatcher（不加入 batchGroup，不 dispatch）
+
+2. startBatcher 收到 DDL 后：
+   a. 先 dispatch 当前 batchGroup 中的 DML 到 workers
+   b. 等待所有 workers 完成（waitForAllWorkersIdle）
+   c. DDL 由 batcher 直接同步执行到目标库（DDLExecutor）
+   d. 执行完后更新 checkpoint
+   e. 继续处理后续 oplog
+```
+
+### 如何解决两个根因
+
+| 根因 | 原始问题 | 修复方案 |
+|------|---------|---------|
+| `checkCheckpointUpdate` 等待不精确 | 比较 checkpoint 时间戳，可能立即成功 | `waitForAllWorkersIdle()` 直接检查 worker 队列状态，等待真正空闲 |
+| DDL/DML 并行执行 | DDL 走 worker[0]，DML 走其他 worker，并行竞争 | DDL 由 batcher 直接执行，天然串行，无并行竞争 |
+
+---
+
+## DML dispatch 与 DDL 处理解耦
+
+原代码将 DML dispatch 和 DDL barrier 耦合在同一个 `else if` 分支：
+
+```go
+} else if log, filterLog := batcher.getLastOplog(); log != nil && !allEmpty {
+    // DML dispatch 和 DDL 处理耦合
+    batcher.dispatchBatches(batchedOplog)
+    if barrier {
+        // DDL 处理...
+    }
+}
+```
+
+**问题**：如果 DDL 没有前置 DML（`allEmpty=true`），整个分支跳过，DDL 不会被处理。
+
+修复后将两者解耦为独立步骤：
+
+```
+Step 1: DML dispatch（独立，不受 allEmpty 影响）
+Step 2: DDL barrier（独立，检查 ddlOplogs 非空）
+```
+
+---
+
+## 修复前后对比
+
+### 修复前
+
+```
+DDL → addIntoBatchGroup → worker[0] ──► Executor ──► Target
+                                        ↑
+                                    并行执行
+                                        ↓
+DML → addIntoBatchGroup → worker[N] ──► Executor ──► Target
+
+⚠️ DDL 和 DML 在不同 worker 中并行，顺序不可控
+⚠️ checkCheckpointUpdate 等待 checkpoint 时间戳，不精确
+```
+
+### 修复后
+
+```
+DML → dispatch 到 workers → waitForAllWorkersIdle → 等待完成
+                                                          │
+                                                          ▼
+                                          DDL → DDLExecutor → Target（batcher 直接执行）
+                                                          │
+                                                          ▼
+                                              checkpoint(true, ddlTs)
+                                                          │
+                                                          ▼
+                                              继续处理后续 oplog
+
+✅ DDL 不进 worker 管道，batcher 直接同步执行
+✅ waitForAllWorkersIdle 等待所有 DML 真正完成
+✅ 天然串行，无竞争条件
+```
+
+---
+
+## 非 direct tunnel 降级
+
+对于 `kafka` / `tcp` / `rpc` / `file` tunnel，DDL 仍走 `worker[0]` 执行，保持原有行为。原因：
+
+- 非 direct tunnel 场景下，DDL 在 receiver 端执行，不存在同样的竞争条件
+- Receiver 是单点消费，天然串行
+
+---
+
+## 测试
+
+### 单元测试
+
+| 测试 | 覆盖 |
+|------|------|
+| `TestBatchMore_ReturnsDDLOplogs` | DDL 通过返回值传递，不加入 batchGroup |
+| `TestWaitForAllWorkersIdle_AllIdle` | 所有 worker 队列为空且 ack==unack |
+| `TestWaitForAllWorkersIdle_SomeBusy` | 部分 worker 队列非空，持续等待 |
+| `TestWaitForAllWorkersIdle_PauseInterrupt` | Pause 信号中断等待 |
+| `TestExecuteDDLDirectly_DirectTunnel` | Direct tunnel 时调用 DDLExecutor |
+| `TestExecuteDDLDirectly_NonDirectTunnel` | Non-direct tunnel 时降级到 worker[0] |
+
+### 集成测试
+
+| Case | 操作序列 | 验证 |
+|------|---------|------|
+| A | 大量 insert → drop collection | 目标端 collection 应不存在（无残留数据） |
+| B | create collection → insert → drop | 无 `Collection already exists` 错误 |
+| C | insert → rename → insert | 数据写入正确集合，无丢失 |
+
+---
+
+## 影响范围
+
+- **仅影响 direct tunnel**：Non-direct tunnel 保持原有行为
+- **DDL 延迟增加**：DDL 必须等待所有前置 DML 完成，这是正确行为
+- **运维可中断**：保留 Pause/Shutdown 感知，运维始终可中断长时间等待
+
+---
+
+## 改动文件清单
+
+| 文件 | 改动 |
+|------|------|
+| `collector/batcher.go` | 新增 DDLExecutor、waitForAllWorkersIdle、executeDDLDirectly；修改 BatchMore 返回值 |
+| `collector/syncer.go` | 解耦 DML dispatch 与 DDL 处理 |
+| `collector/batcher_test.go` | 适配 BatchMore 新签名 |


### PR DESCRIPTION
## Problem

DDL operations were not guaranteed to execute in the correct order relative to DML operations, causing data inconsistency:

1. DDL may execute before preceding DML
2. DDL may execute after succeeding DML

## Root Causes

1. `checkCheckpointUpdate` waits for checkpoint timestamp, not actual DML completion
2. DDL and DML execute in parallel across different workers

## Solution

DDL bypasses the worker pipeline and is executed synchronously by the Batcher goroutine, ensuring natural serialization with DML.

## Files Changed

- `collector/batcher.go`
- `collector/syncer.go`
- `collector/batcher_test.go`
- `docs/fixes/ddl-barrier-race-condition.md`

## Details

See [docs/fixes/ddl-barrier-race-condition.md](docs/fixes/ddl-barrier-race-condition.md) for full analysis and implementation details.

Fixes #934