### PR TITLE
fix: remove defer exec.conn.Close() from DocExecutor.start()

### DIFF
--- a/collector/docsyncer/doc_executor.go
+++ b/collector/docsyncer/doc_executor.go
@@ -155,9 +155,12 @@ func (exec *DocExecutor) String() string {
 }
 
 func (exec *DocExecutor) start() {
-	if !conf.Options.FullSyncExecutorDebug {
-		defer exec.conn.Close()
-	}
+	// NOTE: do NOT close exec.conn here — all DocExecutors within a
+	// CollectionExecutor share the same connection.  Closing it from one
+	// goroutine would tear down the connection for all others, causing
+	// "use of closed network connection" panics.
+	// CollectionExecutor.Wait() is responsible for closing the shared
+	// connection after all workers have finished.
 
 	for {
 		docs, ok := <-exec.colExecutor.docBatch


### PR DESCRIPTION
## 问题
全量同步场景下，DocExecutor.start() 中 defer exec.conn.Close() 会在任意一个 DocExecutor panic 时关闭共享连接，导致其他 7 个 DocExecutor 全部报 use of closed network connection 连锁 panic，进程崩溃。

## 根因
CollectionExecutor 创建 1 个连接，8 个 DocExecutor 共享。CollectionExecutor.Wait() 已经负责关闭连接，DocExecutor 中的 defer close 是多余的且有害。

## 修复
删掉 DocExecutor.start() 中的 defer exec.conn.Close()，连接由 CollectionExecutor.Wait() 统一管理。