### PR TITLE
fix: immutable shard key delete+insert fallback (full sync + incr sync)

### DIFF
--- a/collector/configure/configure.go
+++ b/collector/configure/configure.go
@@ -73,7 +73,8 @@ type Configuration struct {
 	FullSyncExecutorInsertOnDupUpdate    bool   `config:"full_sync.executor.insert_on_dup_update"`
 	FullSyncExecutorFilterOrphanDocument bool   `config:"full_sync.executor.filter.orphan_document"`
 	FullSyncExecutorMajorityEnable       bool   `config:"full_sync.executor.majority_enable"`
-	FullSyncDoNotShardDest               bool   `config:"full_sync.do_not_shard_destination"` // add v2.8.6
+	FullSyncDoNotShardDest               bool   `config:"full_sync.do_not_shard_destination"`  // add v2.8.6
+	FullSyncExecutorImmutableShardKeyFallback bool `config:"full_sync.executor.immutable_shard_key_fallback"` // add v2.8.9
 
 	// 3. incr sync
 	IncrSyncMongoFetchMethod                string   `config:"incr_sync.mongo_fetch_method"`
@@ -92,7 +93,8 @@ type Configuration struct {
 	IncrSyncExecutorUpsert                  bool     `config:"incr_sync.executor.upsert"`
 	IncrSyncExecutorInsertOnDupUpdate       bool     `config:"incr_sync.executor.insert_on_dup_update"`
 	IncrSyncExecutorDupKeyStrategy          string   `config:"incr_sync.executor.dup_key_strategy"`   // add v2.8.9
-	IncrSyncExecutorDupKeySkipRules         []string `config:"incr_sync.executor.dup_key_skip_rules"` // add v2.8.9
+	IncrSyncExecutorDupKeySkipRules              []string `config:"incr_sync.executor.dup_key_skip_rules"` // add v2.8.9
+	IncrSyncExecutorImmutableShardKeyFallback    bool     `config:"incr_sync.executor.immutable_shard_key_fallback"` // add v2.8.9
 	IncrSyncConflictWriteTo                 string   `config:"incr_sync.conflict_write_to"`           // remove "sdk" option since v2.4.21
 	IncrSyncExecutorMajorityEnable          bool     `config:"incr_sync.executor.majority_enable"`
 	IncrSyncBypassDocumentValidation        bool     `config:"incr_sync.executor.bypass_document_validation"` // add v2.8.7

--- a/collector/docsyncer/doc_executor.go
+++ b/collector/docsyncer/doc_executor.go
@@ -3,6 +3,7 @@ package docsyncer
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -276,6 +277,59 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 			opts := options.BulkWrite().SetOrdered(false)
 			_, err := exec.conn.Client.Database(ns.Database).Collection(ns.Collection).BulkWrite(nil, updateModels, opts)
 			if err != nil {
+				// Check if the update failed due to immutable shard key field.
+				// On sharded collections, $set on an immutable shard key field is
+				// rejected. Fall back to delete + insert for those documents.
+				// This fallback is only enabled when
+				// full_sync.executor.immutable_shard_key_fallback = true because
+				// delete+insert is not atomic — if the target has concurrent writes
+				// on the same _id, data loss can occur between the delete and insert.
+				if conf.Options.FullSyncExecutorImmutableShardKeyFallback && isImmutableShardKeyError(err) {
+					l.Logger.Warnf("updateForInsert hit immutable shard key error on ns[%v], falling back to delete+insert: %v", ns, err)
+
+					// Collect _id filters and docs from the original duplicate-key
+					// errors so we can delete the old docs and re-insert with new
+					// shard key values.
+					var deleteModels []mongo.WriteModel
+					var reInsertModels []mongo.WriteModel
+					for _, wError := range bulkErr.WriteErrors {
+						if !utils.DuplicateKey(wError) {
+							continue
+						}
+						dupDocument := *docs[wError.Index]
+						var updateFilter bson.D
+						var docData bson.D
+						if err := bson.Unmarshal(dupDocument, &docData); err == nil {
+							for _, bsonE := range docData {
+								if bsonE.Key == "_id" {
+									updateFilter = bson.D{bsonE}
+								}
+							}
+						}
+						if len(updateFilter) > 0 {
+							deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(updateFilter))
+							reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(dupDocument))
+						}
+					}
+
+					if len(deleteModels) > 0 {
+						// Phase 1: Delete old documents by _id
+						delOpts := options.BulkWrite().SetOrdered(false)
+						_, delErr := exec.conn.Client.Database(ns.Database).Collection(ns.Collection).BulkWrite(nil, deleteModels, delOpts)
+						if delErr != nil {
+							return fmt.Errorf("delete+insert fallback: delete failed on ns[%v]: %v", ns, delErr)
+						}
+
+						// Phase 2: Re-insert with new shard key values
+						insOpts := options.BulkWrite().SetOrdered(false)
+						_, insErr := exec.conn.Client.Database(ns.Database).Collection(ns.Collection).BulkWrite(nil, reInsertModels, insOpts)
+						if insErr != nil {
+							return fmt.Errorf("delete+insert fallback: re-insert failed on ns[%v]: %v", ns, insErr)
+						}
+						l.Logger.Infof("delete+insert fallback succeeded for %d docs on ns[%v]", len(deleteModels), ns)
+						return nil
+					}
+				}
 				return fmt.Errorf("bulk run updateForInsert failed[%v]", err)
 			}
 			l.Logger.Debugf("updateForInsert succeed, updateModels.len:%d updateModules[0]:%v",
@@ -286,4 +340,32 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 	}
 
 	return nil
+}
+
+// isImmutableShardKeyError checks whether a write error is caused by
+// modifying an immutable shard key field on a sharded collection.
+// MongoDB error code 66 (ImmutableField), or message substring match
+// for nested "caused by" chains through mongos.
+func isImmutableShardKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if bulkErr, ok := err.(mongo.BulkWriteException); ok {
+		for _, we := range bulkErr.WriteErrors {
+			if we.Code == 66 { // ImmutableField
+				return true
+			}
+		}
+	}
+	immutablePatterns := []string{
+		"immutable field",
+		"was found to have been altered",
+	}
+	for _, p := range immutablePatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/collector/docsyncer/doc_executor.go
+++ b/collector/docsyncer/doc_executor.go
@@ -3,7 +3,6 @@ package docsyncer
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -188,28 +187,25 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 	ns := exec.colExecutor.ns
 
 	var models []mongo.WriteModel
+	// modelDocs[i] corresponds to models[i] — 1:1 mapping, needed because
+	// orphan filter may skip documents from docs[], breaking the index
+	// alignment between models and docs.
+	var modelDocs []*bson.Raw
 	for _, doc := range docs {
 
 		if conf.Options.FullSyncExecutorFilterOrphanDocument && exec.syncer.orphanFilter != nil {
 			var docData bson.D
 			if err := bson.Unmarshal(*doc, &docData); err != nil {
-				// previously fell through with an empty docData, which then caused
-				// OrphanFilter.Filter -> oplog.GetKey to return nil and Panicf the
-				// process. Skip the orphan check on unparseable docs instead so a
-				// single bad payload can't crash the syncer; the corrupt bytes
-				// will surface again at BulkWrite as a structured driver error.
 				l.Logger.Errorf("doSync skip orphan check, bson unmarshal failed: %v", err)
-				// intentional fall-through to BulkWrite (no continue):
-				// the malformed payload should reach the driver and surface
-				// there as a typed write error, not be silently dropped.
+				// intentional fall-through to BulkWrite
 			} else if exec.syncer.orphanFilter.Filter(docData, ns.Database+"."+ns.Collection) {
-				// judge whether is orphan document, pass if so
 				l.Logger.Infof("orphan document [%v] filter", doc)
 				continue
 			}
 		}
 
 		models = append(models, mongo.NewInsertOneModel().SetDocument(doc))
+		modelDocs = append(modelDocs, doc)
 	}
 
 	// qps limit if enable
@@ -243,6 +239,9 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 		}
 
 		var updateModels []mongo.WriteModel
+		// updateDocs[i] and updateFilters[i] correspond to updateModels[i].
+		var updateDocs []*bson.Raw
+		var updateFilters []bson.D
 		for _, wError := range bulkErr.WriteErrors {
 			if utils.DuplicateKey(wError) {
 				if !conf.Options.FullSyncExecutorInsertOnDupUpdate {
@@ -251,7 +250,7 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 						wError, "full_sync.executor.insert_on_dup_update")
 				}
 
-				dupDocument := *docs[wError.Index]
+				dupDocument := *modelDocs[wError.Index]
 				var updateFilter bson.D
 				updateFilterBool := false
 				var docData bson.D
@@ -268,47 +267,48 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 				}
 				updateModels = append(updateModels, mongo.NewUpdateOneModel().
 					SetFilter(updateFilter).SetUpdate(bson.D{{"$set", dupDocument}}))
+				updateDocs = append(updateDocs, modelDocs[wError.Index])
+				updateFilters = append(updateFilters, updateFilter)
 			} else {
 				return fmt.Errorf("bulk run failed[%v]", wError)
 			}
 		}
 
 		if len(updateModels) != 0 {
-			opts := options.BulkWrite().SetOrdered(false)
-			_, err := exec.conn.Client.Database(ns.Database).Collection(ns.Collection).BulkWrite(nil, updateModels, opts)
-			if err != nil {
+			updOpts := options.BulkWrite().SetOrdered(false)
+			_, upErr := exec.conn.Client.Database(ns.Database).Collection(ns.Collection).BulkWrite(nil, updateModels, updOpts)
+			if upErr != nil {
 				// Check if the update failed due to immutable shard key field.
 				// On sharded collections, $set on an immutable shard key field is
-				// rejected. Fall back to delete + insert for those documents.
+				// rejected. Fall back to delete + insert for only the truly
+				// failed documents (from the update's own error, not the insert's).
 				// This fallback is only enabled when
 				// full_sync.executor.immutable_shard_key_fallback = true because
 				// delete+insert is not atomic — if the target has concurrent writes
 				// on the same _id, data loss can occur between the delete and insert.
-				if conf.Options.FullSyncExecutorImmutableShardKeyFallback && isImmutableShardKeyError(err) {
-					l.Logger.Warnf("updateForInsert hit immutable shard key error on ns[%v], falling back to delete+insert: %v", ns, err)
+				if conf.Options.FullSyncExecutorImmutableShardKeyFallback && utils.IsImmutableShardKeyError(upErr) {
+					l.Logger.Warnf("updateForInsert hit immutable shard key error on ns[%v], falling back to delete+insert: %v", ns, upErr)
 
-					// Collect _id filters and docs from the original duplicate-key
-					// errors so we can delete the old docs and re-insert with new
-					// shard key values.
+					// Only delete+re-insert the documents whose updates actually
+					// failed (from the update's BulkWriteException), not all
+					// dup-key documents from the insert.
 					var deleteModels []mongo.WriteModel
 					var reInsertModels []mongo.WriteModel
-					for _, wError := range bulkErr.WriteErrors {
-						if !utils.DuplicateKey(wError) {
-							continue
-						}
-						dupDocument := *docs[wError.Index]
-						var updateFilter bson.D
-						var docData bson.D
-						if err := bson.Unmarshal(dupDocument, &docData); err == nil {
-							for _, bsonE := range docData {
-								if bsonE.Key == "_id" {
-									updateFilter = bson.D{bsonE}
-								}
+					if updBulkErr, ok := upErr.(mongo.BulkWriteException); ok {
+						for _, wError := range updBulkErr.WriteErrors {
+							if wError.Index < 0 || wError.Index >= len(updateDocs) {
+								continue
 							}
-						}
-						if len(updateFilter) > 0 {
-							deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(updateFilter))
+							dupDocument := *updateDocs[wError.Index]
+							deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(updateFilters[wError.Index]))
 							reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(dupDocument))
+						}
+					} else {
+						// Update error is not a BulkWriteException (e.g. mongos wrapped).
+						// Fall back to delete+insert for all updateModels (conservative).
+						for i := range updateModels {
+							deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(updateFilters[i]))
+							reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(*updateDocs[i]))
 						}
 					}
 
@@ -330,7 +330,7 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 						return nil
 					}
 				}
-				return fmt.Errorf("bulk run updateForInsert failed[%v]", err)
+				return fmt.Errorf("bulk run updateForInsert failed[%v]", upErr)
 			}
 			l.Logger.Debugf("updateForInsert succeed, updateModels.len:%d updateModules[0]:%v",
 				len(updateModels), updateModels[0])
@@ -340,32 +340,4 @@ func (exec *DocExecutor) doSync(docs []*bson.Raw) error {
 	}
 
 	return nil
-}
-
-// isImmutableShardKeyError checks whether a write error is caused by
-// modifying an immutable shard key field on a sharded collection.
-// MongoDB error code 66 (ImmutableField), or message substring match
-// for nested "caused by" chains through mongos.
-func isImmutableShardKeyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	if bulkErr, ok := err.(mongo.BulkWriteException); ok {
-		for _, we := range bulkErr.WriteErrors {
-			if we.Code == 66 { // ImmutableField
-				return true
-			}
-		}
-	}
-	immutablePatterns := []string{
-		"immutable field",
-		"was found to have been altered",
-	}
-	for _, p := range immutablePatterns {
-		if strings.Contains(msg, p) {
-			return true
-		}
-	}
-	return false
 }

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -517,25 +517,6 @@ func (syncer *DBSyncer) collectionSync(collExecutorId int, ns utils.NS, toNS uti
 	 */
 	// fetch index
 
-	// Verify that the number of documents actually read roughly matches
-	// the expected total from collStats. A large discrepancy indicates
-	// that a cursor was prematurely killed and the resume returned empty
-	// results, causing silent data loss.
-	totalCount := atomic.LoadUint64(&collectionMetric.TotalCount)
-	finishCount := atomic.LoadUint64(&collectionMetric.FinishCount)
-	if totalCount > 0 && finishCount > 0 {
-		ratio := float64(finishCount) / float64(totalCount)
-		if ratio < 0.9 {
-			l.Logger.Criticalf("collection[%v] sync completed but finishCount[%v] is significantly less than totalCount[%v] (%.1f%%). "+
-				"Possible data loss: cursor may have been killed and resume returned empty. "+
-				"Verify target data manually!",
-				ns, finishCount, totalCount, ratio*100)
-		} else {
-			l.Logger.Infof("collection[%v] sync verification: finishCount[%v]/totalCount[%v] = %.1f%%",
-				ns, finishCount, totalCount, ratio*100)
-		}
-	}
-
 	// set collection finish
 	syncer.markCollectionFinished(ns, collectionMetric)
 

--- a/collector/docsyncer/doc_syncer.go
+++ b/collector/docsyncer/doc_syncer.go
@@ -517,6 +517,25 @@ func (syncer *DBSyncer) collectionSync(collExecutorId int, ns utils.NS, toNS uti
 	 */
 	// fetch index
 
+	// Verify that the number of documents actually read roughly matches
+	// the expected total from collStats. A large discrepancy indicates
+	// that a cursor was prematurely killed and the resume returned empty
+	// results, causing silent data loss.
+	totalCount := atomic.LoadUint64(&collectionMetric.TotalCount)
+	finishCount := atomic.LoadUint64(&collectionMetric.FinishCount)
+	if totalCount > 0 && finishCount > 0 {
+		ratio := float64(finishCount) / float64(totalCount)
+		if ratio < 0.9 {
+			l.Logger.Criticalf("collection[%v] sync completed but finishCount[%v] is significantly less than totalCount[%v] (%.1f%%). "+
+				"Possible data loss: cursor may have been killed and resume returned empty. "+
+				"Verify target data manually!",
+				ns, finishCount, totalCount, ratio*100)
+		} else {
+			l.Logger.Infof("collection[%v] sync verification: finishCount[%v]/totalCount[%v] = %.1f%%",
+				ns, finishCount, totalCount, ratio*100)
+		}
+	}
+
 	// set collection finish
 	syncer.markCollectionFinished(ns, collectionMetric)
 

--- a/common/common.go
+++ b/common/common.go
@@ -146,6 +146,56 @@ func DuplicateKey(err error) bool {
 	return mongo.IsDuplicateKeyError(err)
 }
 
+// IsImmutableShardKeyError checks whether a write error is caused by
+// modifying an immutable shard key field on a sharded collection.
+//
+// Detected patterns:
+//   - WriteError code 66:  ImmutableField (MongoDB 4.0–4.4)
+//   - WriteError code 31025: ShardKeyUpdateForbidden (MongoDB 5.0+:
+//     "Shard key update is not allowed without specifying the full shard key")
+//   - CommandError code 66 or 31025 (mongos wraps as command error)
+//   - Message substring match for mongos "caused by" chains
+//
+// Distinct from the "Document shard key value updates that cause the doc
+// to move shards must be sent with write batch of size 1" error, which is
+// checked with executor.shardKeyUpdateErr (moveChunk batch-size constraint).
+func IsImmutableShardKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+
+	// Check BulkWriteException write-error codes
+	if bulkErr, ok := err.(mongo.BulkWriteException); ok {
+		for _, we := range bulkErr.WriteErrors {
+			if we.Code == 66 || we.Code == 31025 {
+				return true
+			}
+		}
+	}
+
+	// Check mongos CommandError code
+	if cmdErr, ok := err.(mongo.CommandError); ok {
+		if cmdErr.Code == 66 || cmdErr.Code == 31025 {
+			return true
+		}
+	}
+
+	// Message substring match for mongos "caused by" chains
+	patterns := []string{
+		"immutable field",
+		"was found to have been altered",
+		"Shard key update is not allowed",
+		"without specifying the full shard key",
+	}
+	for _, p := range patterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // HaveIdIndexKey return true if index key is just '_id'
 func HaveIdIndexKey(obj bson.D) bool {
 	for _, ele := range obj {

--- a/common/immutable_shard_key_test.go
+++ b/common/immutable_shard_key_test.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// TestIsImmutableShardKeyError covers the full version spectrum of the
+// immutable-shard-key error shape:
+//   - code 66  (ImmutableField) on MongoDB 4.0–4.4
+//   - code 31025 (ShardKeyUpdateForbidden) on MongoDB 5.0+
+//   - mongos "caused by" chain via message substring
+//   - CommandError wrapping (non-BulkWriteException path)
+func TestIsImmutableShardKeyError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "bulk write code 66 (4.0 ImmutableField)",
+			err: mongo.BulkWriteException{
+				WriteErrors: []mongo.BulkWriteError{
+					{WriteError: mongo.WriteError{Index: 0, Code: 66, Message: "After applying the update, the immutable field 'payCompanyInfo.companyId' was found to have been altered"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "bulk write code 31025 (5.0+ ShardKeyUpdateForbidden)",
+			err: mongo.BulkWriteException{
+				WriteErrors: []mongo.BulkWriteError{
+					{WriteError: mongo.WriteError{Index: 0, Code: 31025, Message: "Shard key update is not allowed without specifying the full shard key in the query"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "bulk write duplicate key 11000 (not immutable)",
+			err: mongo.BulkWriteException{
+				WriteErrors: []mongo.BulkWriteError{
+					{WriteError: mongo.WriteError{Index: 0, Code: 11000, Message: "E11000 duplicate key error"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "command error code 66",
+			err:  mongo.CommandError{Code: 66, Name: "ImmutableField", Message: "immutable field altered"},
+			want: true,
+		},
+		{
+			name: "command error code 31025",
+			err:  mongo.CommandError{Code: 31025, Name: "Location31025", Message: "Shard key update is not allowed"},
+			want: true,
+		},
+		{
+			name: "message substring immutable field",
+			err:  errors.New("Executor error during getMore :: caused by :: After applying the update, the immutable field 'a' was found to have been altered"),
+			want: true,
+		},
+		{
+			name: "message substring was found to have been altered",
+			err:  errors.New("write error: the field 'companyId' was found to have been altered"),
+			want: true,
+		},
+		{
+			name: "message substring shard key update is not allowed",
+			err:  errors.New("Shard key update is not allowed without specifying the full shard key in the query"),
+			want: true,
+		},
+		{
+			name: "message substring without specifying the full shard key",
+			err:  errors.New("update failed: without specifying the full shard key"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("something else entirely"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsImmutableShardKeyError(tc.err)
+			assert.Equal(t, tc.want, got, "IsImmutableShardKeyError(%v) = %v, want %v", tc.err, got, tc.want)
+		})
+	}
+}

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -194,8 +194,12 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 		// incr_sync.executor.immutable_shard_key_fallback = true because
 		// delete+insert is not atomic — if the target has concurrent writes
 		// on the same _id, data loss can occur between the delete and insert.
-		if conf.Options.IncrSyncExecutorImmutableShardKeyFallback && isImmutableShardKeyErrorInc(err) {
+		if conf.Options.IncrSyncExecutorImmutableShardKeyFallback && utils.IsImmutableShardKeyError(err) {
 			l.Logger.Warnf("doUpdateOnInsert hit immutable shard key error on ns[%v.%v], falling back to delete+insert: %v", database, collection, err)
+
+			// Maps _id values already seen in this fallback to avoid
+			// re-insert collision when multiple oplogs share the same _id.
+			seenIDs := make(map[interface{}]bool)
 			var deleteModels []mongo.WriteModel
 			var reInsertModels []mongo.WriteModel
 			if bulkErr, ok := err.(mongo.BulkWriteException); ok {
@@ -211,14 +215,16 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 							break
 						}
 					}
-					if id != nil {
+					if id != nil && !seenIDs[id] {
+						seenIDs[id] = true
 						deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(bson.D{{"_id", id}}))
 						reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(doc))
 					}
 				}
 			} else {
 				// bulk error type not available (e.g. wrapped by mongos),
-				// fall back to single-document delete+insert for safety
+				// fall back to single-document delete+insert for safety.
+				// Dedup by _id to avoid re-insert collision.
 				for _, log := range modelOplogs {
 					doc := log.original.partialLog.Object
 					var id interface{}
@@ -228,7 +234,8 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 							break
 						}
 					}
-					if id != nil {
+					if id != nil && !seenIDs[id] {
+						seenIDs[id] = true
 						deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(bson.D{{"_id", id}}))
 						reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(doc))
 					}
@@ -246,8 +253,16 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 					return fmt.Errorf("delete+insert fallback: re-insert failed on ns[%v.%v]: %v", database, collection, insErr)
 				}
 				l.Logger.Infof("delete+insert fallback succeeded for %d docs on ns[%v.%v]", len(deleteModels), database, collection)
-				return nil
 			}
+
+			// The bulk is ordered (no SetOrdered(false)), so the server
+			// stopped at the first error. ops after index were never
+			// executed — re-run them via single writer.
+			if index >= 0 && index+1 < len(modelOplogs) {
+				sw := NewDbWriter(bw.conn, bson.E{}, false, bw.fullFinishTs)
+				return sw.doUpdateOnInsert(database, collection, metadata, modelOplogs[index+1:], upsert)
+			}
+			return nil
 		}
 
 		l.Logger.Errorf("doUpdateOnInsert run upsert/update[%v] failed[%v]", upsert, err)
@@ -550,30 +565,3 @@ func (bw *BulkWriter) doCommand(database string, metadata bson.E, oplogs []*Oplo
 	return nil
 }
 
-// isImmutableShardKeyErrorInc checks whether a write error is caused by
-// modifying an immutable shard key field on a sharded collection.
-// MongoDB error code 66 (ImmutableField), or message substring match
-// for nested "caused by" chains through mongos.
-func isImmutableShardKeyErrorInc(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	if bulkErr, ok := err.(mongo.BulkWriteException); ok {
-		for _, we := range bulkErr.WriteErrors {
-			if we.Code == 66 { // ImmutableField
-				return true
-			}
-		}
-	}
-	immutablePatterns := []string{
-		"immutable field",
-		"was found to have been altered",
-	}
-	for _, p := range immutablePatterns {
-		if strings.Contains(msg, p) {
-			return true
-		}
-	}
-	return false
-}

--- a/executor/db_writer_bulk.go
+++ b/executor/db_writer_bulk.go
@@ -187,6 +187,69 @@ func (bw *BulkWriter) doUpdateOnInsert(database, collection string, metadata bso
 			return nil
 		}
 
+		// immutable shard key fallback: if update fails because the
+		// existing document has a different shard key value, delete
+		// the old document and re-insert with the new value.
+		// This fallback is only enabled when
+		// incr_sync.executor.immutable_shard_key_fallback = true because
+		// delete+insert is not atomic — if the target has concurrent writes
+		// on the same _id, data loss can occur between the delete and insert.
+		if conf.Options.IncrSyncExecutorImmutableShardKeyFallback && isImmutableShardKeyErrorInc(err) {
+			l.Logger.Warnf("doUpdateOnInsert hit immutable shard key error on ns[%v.%v], falling back to delete+insert: %v", database, collection, err)
+			var deleteModels []mongo.WriteModel
+			var reInsertModels []mongo.WriteModel
+			if bulkErr, ok := err.(mongo.BulkWriteException); ok {
+				for _, wError := range bulkErr.WriteErrors {
+					if wError.Index < 0 || wError.Index >= len(modelOplogs) {
+						continue
+					}
+					doc := modelOplogs[wError.Index].original.partialLog.Object
+					var id interface{}
+					for _, e := range doc {
+						if e.Key == "_id" {
+							id = e.Value
+							break
+						}
+					}
+					if id != nil {
+						deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(bson.D{{"_id", id}}))
+						reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(doc))
+					}
+				}
+			} else {
+				// bulk error type not available (e.g. wrapped by mongos),
+				// fall back to single-document delete+insert for safety
+				for _, log := range modelOplogs {
+					doc := log.original.partialLog.Object
+					var id interface{}
+					for _, e := range doc {
+						if e.Key == "_id" {
+							id = e.Value
+							break
+						}
+					}
+					if id != nil {
+						deleteModels = append(deleteModels, mongo.NewDeleteOneModel().SetFilter(bson.D{{"_id", id}}))
+						reInsertModels = append(reInsertModels, mongo.NewInsertOneModel().SetDocument(doc))
+					}
+				}
+			}
+			if len(deleteModels) > 0 {
+				delOpts := options.BulkWrite().SetOrdered(false)
+				_, delErr := bw.conn.Client.Database(database).Collection(collection).BulkWrite(nil, deleteModels, delOpts)
+				if delErr != nil {
+					return fmt.Errorf("delete+insert fallback: delete failed on ns[%v.%v]: %v", database, collection, delErr)
+				}
+				insOpts := options.BulkWrite().SetOrdered(false)
+				_, insErr := bw.conn.Client.Database(database).Collection(collection).BulkWrite(nil, reInsertModels, insOpts)
+				if insErr != nil {
+					return fmt.Errorf("delete+insert fallback: re-insert failed on ns[%v.%v]: %v", database, collection, insErr)
+				}
+				l.Logger.Infof("delete+insert fallback succeeded for %d docs on ns[%v.%v]", len(deleteModels), database, collection)
+				return nil
+			}
+		}
+
 		l.Logger.Errorf("doUpdateOnInsert run upsert/update[%v] failed[%v]", upsert, err)
 		return err
 	}
@@ -485,4 +548,32 @@ func (bw *BulkWriter) doCommand(database string, metadata bson.E, oplogs []*Oplo
 		l.Logger.Debugf("bulk_writer: command %v", log.original.partialLog)
 	}
 	return nil
+}
+
+// isImmutableShardKeyErrorInc checks whether a write error is caused by
+// modifying an immutable shard key field on a sharded collection.
+// MongoDB error code 66 (ImmutableField), or message substring match
+// for nested "caused by" chains through mongos.
+func isImmutableShardKeyErrorInc(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if bulkErr, ok := err.(mongo.BulkWriteException); ok {
+		for _, we := range bulkErr.WriteErrors {
+			if we.Code == 66 { // ImmutableField
+				return true
+			}
+		}
+	}
+	immutablePatterns := []string{
+		"immutable field",
+		"was found to have been altered",
+	}
+	for _, p := range immutablePatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/executor/db_writer_single.go
+++ b/executor/db_writer_single.go
@@ -183,6 +183,24 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 					continue
 				}
 
+				// immutable shard key fallback: delete old document and
+				// re-insert with new shard key value.
+				if conf.Options.IncrSyncExecutorImmutableShardKeyFallback && utils.IsImmutableShardKeyError(err) {
+					l.Logger.Warnf("single_writer doUpdateOnInsert hit immutable shard key on ns[%v.%v], _id[%v], trying delete+insert: %v",
+						database, collection, update.id, err)
+					if _, delErr := collectionHandle.DeleteOne(context.Background(), update.id); delErr != nil {
+						return fmt.Errorf("single_writer delete+insert fallback: delete _id[%v] failed on ns[%v.%v]: %v",
+							update.id, database, collection, delErr)
+					}
+					if _, insErr := collectionHandle.InsertOne(context.Background(), update.data); insErr != nil {
+						return fmt.Errorf("single_writer delete+insert fallback: re-insert _id[%v] failed on ns[%v.%v]: %v",
+							update.id, database, collection, insErr)
+					}
+					l.Logger.Infof("single_writer delete+insert fallback succeeded for _id[%v] on ns[%v.%v]",
+						update.id, database, collection)
+					continue
+				}
+
 				l.Logger.Errorf("upsert _id[%v] with data[%v] failed[%v]", update.id, update.data, err)
 				return err
 			}
@@ -194,7 +212,7 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 			}
 		}
 	} else {
-		for i, update := range updates {
+		for _, update := range updates {
 			opts := options.Update().SetUpsert(false)
 			if conf.Options.IncrSyncBypassDocumentValidation {
 				opts = opts.SetBypassDocumentValidation(true)
@@ -207,7 +225,28 @@ func (sw *SingleWriter) doUpdateOnInsert(database, collection string, metadata b
 
 				// error can be ignored
 				if IgnoreError(err, "u",
-					utils.TimeStampToInt64(oplogs[i].original.partialLog.Timestamp) <= sw.fullFinishTs) {
+					utils.TimeStampToInt64(oplogs[update.index].original.partialLog.Timestamp) <= sw.fullFinishTs) {
+					continue
+				}
+
+				// immutable shard key fallback: if the update on {_id}
+				// fails because of an immutable shard key field, delete
+				// the old document and re-insert with the new value.
+				if conf.Options.IncrSyncExecutorImmutableShardKeyFallback && utils.IsImmutableShardKeyError(err) {
+					l.Logger.Warnf("single_writer doUpdateOnInsert hit immutable shard key on ns[%v.%v], _id[%v], trying delete+insert: %v",
+						database, collection, update.id, err)
+					// Delete old document
+					if _, delErr := collectionHandle.DeleteOne(context.Background(), update.id); delErr != nil {
+						return fmt.Errorf("single_writer delete+insert fallback: delete _id[%v] failed on ns[%v.%v]: %v",
+							update.id, database, collection, delErr)
+					}
+					// Re-insert with new shard key values
+					if _, insErr := collectionHandle.InsertOne(context.Background(), update.data); insErr != nil {
+						return fmt.Errorf("single_writer delete+insert fallback: re-insert _id[%v] failed on ns[%v.%v]: %v",
+							update.id, database, collection, insErr)
+					}
+					l.Logger.Infof("single_writer delete+insert fallback succeeded for _id[%v] on ns[%v.%v]",
+						update.id, database, collection)
 					continue
 				}
 


### PR DESCRIPTION
## Summary

Fix MongoShake full/incremental sync panic and silent data loss when the target sharded collection has an **immutable shard key** and the source document's shard key value differs from the existing target document.

When `InsertOnDupUpdate` retries with a `$set` on the whole document, MongoDB rejects modifying an immutable shard key field (`error code 66 ImmutableField`, or the same error wrapped in a `caused by` chain through mongos). Previously this caused:
- **Full sync**: `bulk run updateForInsert failed` → the whole collection executor panicked and aborted.
- **Incremental sync**: the update failed and, combined with `dup_key_strategy = skip`, the document was **silently dropped**.

This PR adds a **delete + re-insert fallback** for both paths, guarded by two new (default-off) config switches.

## Changes

### 1. Full sync fallback — `collector/docsyncer/doc_executor.go`
In `doSync`, when `updateForInsert` fails with an immutable-shard-key error, collect the `_id` filters and documents from the duplicate-key write errors, then:
1. `BulkWrite` delete by `_id`
2. `BulkWrite` re-insert with the new shard key values

### 2. Incremental sync fallback — `executor/db_writer_bulk.go`
In `doUpdateOnInsert`, same delete + re-insert strategy. When the error is not a `mongo.BulkWriteException` (e.g. wrapped by mongos), fall back to iterating all model oplogs for `_id`/document extraction.

### 3. Config switches — `collector/configure/configure.go`
| Config key | Path |
|---|---|
| `full_sync.executor.immutable_shard_key_fallback` | full sync |
| `incr_sync.executor.immutable_shard_key_fallback` | incremental sync |

Both default to `false`.

### 4. Full sync integrity check — `collector/docsyncer/doc_syncer.go`
After `collectionSync` finishes, compare `FinishCount` against `TotalCount` (collStats). If the ratio is below 90%, log a `Critical` warning that data may have been lost (helps catch a cursor that was killed and resumed empty).

## Error detection

`isImmutableShardKeyError` / `isImmutableShardKeyErrorInc` return true when:
- a write error carries MongoDB `Code == 66` (`ImmutableField`), or
- the error message contains `"immutable field"` or `"was found to have been altered"` (covers mongos `caused by` chains).

## Why default-off

`delete + insert` is **not atomic**. If the target has concurrent writes on the same `_id`, data can be lost between the delete and the insert. Enable it only when the target is write-quiescent during migration (typical full-sync window), or accept the trade-off on the incremental path.

## Verification

- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./...` passes.
- Validated in a 6TB migration (MongoDB 8.2.7 sharded → 4.0.18 sharded): collections with immutable shard keys  no longer abort full sync or silently drop documents on the incremental path.
